### PR TITLE
fix(product-media-gallery): subscribe to variantChange via PUB_SUB_EVENTS

### DIFF
--- a/sections/main-product-parfums.liquid
+++ b/sections/main-product-parfums.liquid
@@ -3,7 +3,7 @@
   class="section-{{ section.id }}-padding gradient color-{{ section.settings.color_scheme }}"
   data-section="{{ section.id }}"
   data-product-id="{{ product.id }}"
-  data-update-url="false"
+  data-update-url="true"
   data-url="{{ product.url }}"
   {% if section.settings.image_zoom == 'hover' %}
     data-zoom-on-hover

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -3,7 +3,7 @@
   class="section-{{ section.id }}-padding gradient color-{{ section.settings.color_scheme }}"
   data-section="{{ section.id }}"
   data-product-id="{{ product.id }}"
-  data-update-url="false"
+  data-update-url="true"
   data-url="{{ product.url }}"
   {% if section.settings.image_zoom == 'hover' %}
     data-zoom-on-hover

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1407,71 +1407,36 @@
       }
 
       // Set up event listeners
+      //
+      // Subscribe to the theme's variant pub/sub. This is the canonical Dawn
+      // pattern (see assets/pubsub.js + assets/product-info.js) and survives
+      // <variant-selects> DOM swaps performed by HTMLUpdateUtility.viewTransition.
+      // Direct radio listeners would die after the first swap; the URL-poll
+      // fallback breaks when data-update-url="false". Pub/sub avoids both.
       function setupEventListeners() {
-        // Listen for radio button changes (use data-option-type for language-agnostic detection)
-        document.querySelectorAll('[data-option-type="color"] input[type="radio"]')
-          .forEach(radio => {
-            radio.addEventListener('change', e => {
-              const newColor = e.target.value;
-              handleColorChange(newColor);
-            });
-          });
+        // `subscribe` and `PUB_SUB_EVENTS` are script-scope globals from
+        // assets/pubsub.js + assets/constants.js — accessible by name but
+        // not as window properties (top-level `const` doesn't attach to window).
+        if (typeof subscribe !== 'function' || typeof PUB_SUB_EVENTS === 'undefined') return;
 
-        // Listen for variant select changes
-        document.querySelectorAll('[data-option-type="color"] select')
-          .forEach(select => {
-            select.addEventListener('change', e => {
-              const newColor = e.target.value;
-              handleColorChange(newColor);
-            });
-          });
+        // Avoid duplicate subscriptions on theme-editor section reloads.
+        if (window.__nfGalleryVariantUnsub) {
+          window.__nfGalleryVariantUnsub();
+        }
 
-        // Listen for Shopify's variant change event
-        document.addEventListener('variant:changed', function(event) {
-          if (event.detail.variant) {
-            // Extract color from variant using pre-computed index
-            const colorPosition = colorOptionIndex;
+        window.__nfGalleryVariantUnsub = subscribe(PUB_SUB_EVENTS.variantChange, ({ data }) => {
+          const variant = data && data.variant;
+          if (!variant) return;
 
-            let newColor = '';
-            if (colorPosition >= 0 && event.detail.variant.options) {
-              newColor = event.detail.variant.options[colorPosition];
-            } else if (event.detail.variant.title) {
-              newColor = event.detail.variant.title.split('/')[0].trim();
-            }
-
-            if (newColor) {
-              handleColorChange(newColor);
-            }
+          let newColor = '';
+          if (colorOptionIndex >= 0 && variant.options) {
+            newColor = variant.options[colorOptionIndex];
+          } else if (variant.title) {
+            newColor = variant.title.split('/')[0].trim();
           }
+
+          if (newColor) handleColorChange(newColor);
         });
-
-        // Listen for URL changes for variant updates
-        let currentUrl = window.location.href;
-        setInterval(() => {
-          if (currentUrl !== window.location.href) {
-            currentUrl = window.location.href;
-            const variantId = new URLSearchParams(window.location.search).get('variant');
-
-            if (variantId) {
-              const variants = {{ product.variants | json }};
-              const variant = variants.find(v => v.id.toString() === variantId);
-
-              if (variant) {
-                // Extract color from variant using pre-computed index
-                const colorPosition = colorOptionIndex;
-
-                let color = colorPosition >= 0 && variant.options ? variant.options[colorPosition] : '';
-                if (!color && variant.title) {
-                  color = variant.title.split('/')[0].trim();
-                }
-
-                if (color) {
-                  handleColorChange(color);
-                }
-              }
-            }
-          }
-        }, 300);
       }
 
       // Start processing media and set up listeners
@@ -1492,30 +1457,6 @@
         }
       });
 
-      // Directly hook into Shopify's variant change mechanism
-      const originalOnVariantChange = window.onVariantChange;
-      window.onVariantChange = function(variant) {
-        if (variant) {
-          // Extract color from variant using pre-computed index
-          const colorPosition = colorOptionIndex;
-
-          let newColor = '';
-          if (colorPosition >= 0 && variant.options) {
-            newColor = variant.options[colorPosition];
-          } else if (variant.title) {
-            newColor = variant.title.split('/')[0].trim();
-          }
-
-          if (newColor) {
-            handleColorChange(newColor);
-          }
-        }
-
-        // Call the original handler if it exists
-        if (typeof originalOnVariantChange === 'function') {
-          originalOnVariantChange(variant);
-        }
-      };
     }
 
     // Function to open the lightbox with filtered and sorted images


### PR DESCRIPTION
## Summary

Variant switching (color swatches) on the PDP would stop updating the gallery image after 1–3 clicks. After commit 73f42c0c (`data-update-url="false"`), the underlying fragility of the custom media gallery's variant-change detection was exposed.

## Root cause

`snippets/product-media-gallery.liquid` had three variant-change paths, all unreliable:

1. **Direct `change` listeners** on color radio inputs — lost when `HTMLUpdateUtility.viewTransition` swaps the `<variant-selects>` DOM (in `product-info.js`).
2. **`document.addEventListener('variant:changed', …)`** — never fires; the theme uses `PUB_SUB_EVENTS.optionValueSelectionChange` / `variantChange`, not a DOM event.
3. **`setInterval` URL polling every 300ms** — only fires when the URL changes, which `data-update-url="false"` disabled.

With `data-update-url="true"`, path 3 hid the bug. Disabling it exposed it.

## Fix

- Replace ad-hoc listeners with a single `subscribe(PUB_SUB_EVENTS.variantChange, …)` subscription — matches Dawn's canonical pattern (see `price-per-item.js`, `recipient-form.js`).
- The subscription survives `viewTransition` DOM swaps and removes the polling `setInterval`.
- Restore `data-update-url="true"` in both `main-product.liquid` and `main-product-parfums.liquid` for shareable variant URLs.
- Guards: `typeof subscribe` / `typeof PUB_SUB_EVENTS === 'undefined'` (since `const` declarations don't attach to `window`); `window.__nfGalleryVariantUnsub` to prevent duplicate subscriptions on theme-editor reloads.

## Diff

3 files changed, **27 insertions, 86 deletions** (net simplification).

## Verification

- ✅ Vitest: 156/156 tests pass (only an unrelated DeepL quota test fails).
- ✅ Live test on production: simulated the new `subscribe(PUB_SUB_EVENTS.variantChange, …)` callback; clicked through 4 colors — all 4 fired with the correct color and variant ID and the gallery image followed.

## Test URL

https://shop.northfinder.com/products/mens-trekking-hybrid-softshell-active-jacket-ciro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes variant-change handling and URL update behavior on the product page, which can affect gallery responsiveness and browser history/URL state across variants.
> 
> **Overview**
> Fixes PDP variant switching so the media gallery reliably updates after repeated option changes by replacing ad-hoc variant detection (DOM `change` listeners, non-firing `variant:changed` event, and URL polling) with a single `subscribe(PUB_SUB_EVENTS.variantChange, …)` handler in `product-media-gallery.liquid`, including guards and an unsubscribe to avoid duplicate subscriptions.
> 
> Re-enables variant URL updates by flipping `data-update-url` back to `true` in both `main-product.liquid` and `main-product-parfums.liquid`, restoring shareable variant URLs and removing reliance on URL polling for gallery updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70841331c64628b700871aecd74929347aa2242f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->