### PR TITLE
feat(localization): cross-market language link in language selector

### DIFF
--- a/assets/localization-form.js
+++ b/assets/localization-form.js
@@ -106,6 +106,10 @@ if (!customElements.get('localization-form')) {
       }
 
       onItemClick(event) {
+        if (event.currentTarget.dataset.externalMarket === 'true') {
+          this.hidePanel();
+          return;
+        }
         event.preventDefault();
         const form = this.querySelector('form');
         this.elements.input.value = event.currentTarget.dataset.value;

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -132,6 +132,10 @@
     "cart_color_scheme": "scheme-1",
     "contact_page_url": "shopify://pages/contact",
     "seo_noindex_enabled": true,
+    "cross_market_language_url": "https://northfinder.bg/",
+    "cross_market_language_label": "Български",
+    "cross_market_language_iso": "bg",
+    "cross_market_host_match": "northfinder.bg",
     "sections": {
       "main-password-header": {
         "type": "main-password-header",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1552,5 +1552,38 @@
         "default": false
       }
     ]
+  },
+  {
+    "name": "Cross-market language link",
+    "settings": [
+      {
+        "type": "paragraph",
+        "content": "Adds an extra entry to the language selector that links to a separate Shopify Markets instance (different domain). Use when a language lives on its own market/domain (e.g., Bulgarian on northfinder.bg) and should still be discoverable from the language picker."
+      },
+      {
+        "type": "url",
+        "id": "cross_market_language_url",
+        "label": "External market URL"
+      },
+      {
+        "type": "text",
+        "id": "cross_market_language_label",
+        "label": "Display label",
+        "info": "Endonym shown in the language list (e.g. Български)."
+      },
+      {
+        "type": "text",
+        "id": "cross_market_language_iso",
+        "label": "Language ISO code",
+        "info": "Two-letter code used for hreflang/lang attributes (e.g. bg)."
+      },
+      {
+        "type": "text",
+        "id": "cross_market_host_match",
+        "label": "External market host",
+        "info": "Hostname of the external market (e.g. northfinder.bg). Used to hide the link when the visitor is already on that market.",
+        "default": "northfinder.bg"
+      }
+    ]
   }
 ]

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -41,6 +41,38 @@
           </a>
         </li>
       {%- endfor -%}
+      {%- liquid
+        assign cross_market_url = settings.cross_market_language_url
+        assign cross_market_label = settings.cross_market_language_label
+        assign cross_market_iso = settings.cross_market_language_iso
+        assign cross_market_host = settings.cross_market_host_match
+        assign show_cross_market = false
+        if cross_market_url != blank and cross_market_label != blank
+          assign show_cross_market = true
+          if cross_market_host != blank and request.host contains cross_market_host
+            assign show_cross_market = false
+          endif
+        endif
+      -%}
+      {%- if show_cross_market -%}
+        <li class="disclosure__item disclosure__item--external" tabindex="-1">
+          <a
+            class="link link--text disclosure__link caption-large focus-inset"
+            href="{{ cross_market_url }}"
+            {% if cross_market_iso != blank %}
+              hreflang="{{ cross_market_iso }}"
+              lang="{{ cross_market_iso }}"
+            {% endif %}
+            rel="alternate"
+            data-external-market="true"
+          >
+            <span class="visibility-hidden">
+              {{- 'icon-checkmark.svg' | inline_asset_content -}}
+            </span>
+            <span>{{ cross_market_label | capitalize }}</span>
+          </a>
+        </li>
+      {%- endif -%}
     </ul>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Adds a cross-market language link to the existing language selector so visitors can hop from the international storefront (e.g. `shop.northfinder.com`) to a separate Shopify Markets instance on a different domain (e.g. `northfinder.bg`). Built off the Dawn `<localization-form>` pattern; the extra `<li>` lives inside the same dropdown and renders in all three placements (announcement bar, footer, header drawer).

Context: Daniel asked for Български to be reachable from the language picker even though it lives on a different market/domain. Shopify's localization form can only switch locale within the current market, so the extra entry bypasses the form and navigates cross-domain.

## Changes

- `config/settings_schema.json` — new "Cross-market language link" settings group (URL, label, ISO, host match).
- `snippets/language-localization.liquid` — append external `<li>` with `data-external-market="true"`, hidden when the visitor is already on the external host (`request.host contains` settings host).
- `assets/localization-form.js` — `onItemClick` early-returns on `data-external-market` so the browser navigates instead of submitting the locale form.
- `config/settings_data.json` — pre-fill BG values (`https://northfinder.bg/`, `Български`, `bg`, `northfinder.bg`) so the feature is active on deploy without any Theme Editor step.

## How it works

Local market languages (English/Hrvatski/Slovenščina/Deutsch) submit `locale_code` as before and stay on the current market. Selecting **Български** does a normal anchor navigation to `https://northfinder.bg/`, where Shopify Markets serves the BG storefront. The entry auto-hides when visiting from `northfinder.bg` to avoid a self-link.

## Caveats

- **Cart state** is lost on switch (different Shopify Markets = different checkout). Cannot be preserved.
- **hreflang cross-market** is already auto-emitted in `<head>` by Shopify Markets web presence; the `rel="alternate"` + `hreflang="bg"` on the link is a complement for SEO/accessibility.
- `settings_data.json` was pre-filled here, but Shopify bot updates that file too. Future changes via Theme Editor will still work.

## Verification

Pushed as unpublished theme `qa-cross-market-language` (#199891878220) on `sportfinder-international.myshopify.com`. Verified via Shopify share-preview URL (bypasses Markets edge cache):

```
{
  "externalCount": 3,                          // announcement bar + footer + header drawer
  "externalHrefs": ["https://northfinder.bg/", ...],
  "externalTexts": ["Български", "Български", "Български"],
  "footerLangs":   ["English", "Hrvatski", "Slovenščina", "Deutsch", "Български"],
  "announceLangs": ["English", "Hrvatski", "Slovenščina", "Deutsch", "Български"],
  "drawerLangs":   ["English", "Hrvatski", "Slovenščina", "Deutsch", "Български"]
}
```

Link attributes confirmed: `href=https://northfinder.bg/`, `hreflang=bg`, `lang=bg`, `rel=alternate`, JS handler skips form submission for `data-external-market="true"`.

Screenshot of footer selector (draft theme bar visible at bottom) attached below.

## Test plan

1. Pull this branch, run `pnpm dev` or push to a draft theme.
2. Open any storefront page on `shop.northfinder.com` (or staging equivalent).
3. Open language selector in: announcement bar, footer, mobile drawer (hamburger).
4. Verify last entry is **Български** with checkmark visibility-hidden and `href="https://northfinder.bg/"`.
5. Click it → browser navigates to `northfinder.bg` (no `/localization` POST in network panel).
6. Open `https://northfinder.bg/` in same browser → Български entry should be hidden in the BG market selector (host match guard).
