### PR TITLE
fix(localization): real-market verification + nfFixLinks rewriter exclusion

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -136,6 +136,9 @@
     "cross_market_language_label": "Български",
     "cross_market_language_iso": "bg",
     "cross_market_host_match": "northfinder.bg",
+    "cross_market_home_url": "https://shop.northfinder.com/",
+    "cross_market_home_label": "English",
+    "cross_market_home_iso": "en",
     "sections": {
       "main-password-header": {
         "type": "main-password-header",

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -132,10 +132,7 @@
     "cart_color_scheme": "scheme-1",
     "contact_page_url": "shopify://pages/contact",
     "seo_noindex_enabled": true,
-    "cross_market_language_url": "https://northfinder.bg/",
-    "cross_market_language_label": "Български",
-    "cross_market_language_iso": "bg",
-    "cross_market_host_match": "northfinder.bg",
+    "cross_market_language_menu": "cross-market-languages",
     "sections": {
       "main-password-header": {
         "type": "main-password-header",

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -132,7 +132,10 @@
     "cart_color_scheme": "scheme-1",
     "contact_page_url": "shopify://pages/contact",
     "seo_noindex_enabled": true,
-    "cross_market_language_menu": "cross-market-languages",
+    "cross_market_language_url": "https://northfinder.bg/",
+    "cross_market_language_label": "Български",
+    "cross_market_language_iso": "bg",
+    "cross_market_host_match": "northfinder.bg",
     "sections": {
       "main-password-header": {
         "type": "main-password-header",

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -137,8 +137,6 @@
     "cross_market_language_iso": "bg",
     "cross_market_host_match": "northfinder.bg",
     "cross_market_home_url": "https://shop.northfinder.com/",
-    "cross_market_home_label": "English",
-    "cross_market_home_iso": "en",
     "sections": {
       "main-password-header": {
         "type": "main-password-header",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1558,13 +1558,31 @@
     "settings": [
       {
         "type": "paragraph",
-        "content": "Appends extra entries to the language selector that link to other Shopify Markets instances on a different domain (e.g. Bulgarian on northfinder.bg, English on shop.northfinder.com). Create a menu in Online Store → Navigation with one link per external market, then pick it below. Each menu item's URL is the destination, the title is the display label. Entries whose URL host matches the current visitor's domain auto-hide to avoid self-linking."
+        "content": "Adds an extra entry to the language selector that links to a separate Shopify Markets instance (different domain). Use when a language lives on its own market/domain (e.g., Bulgarian on northfinder.bg) and should still be discoverable from the language picker."
       },
       {
-        "type": "link_list",
-        "id": "cross_market_language_menu",
-        "label": "External markets menu",
-        "info": "Menu of links to other markets (e.g. \"cross-market-languages\"). Each item's title becomes the display label; the URL determines the destination and the host used for the self-link guard."
+        "type": "url",
+        "id": "cross_market_language_url",
+        "label": "External market URL"
+      },
+      {
+        "type": "text",
+        "id": "cross_market_language_label",
+        "label": "Display label",
+        "info": "Endonym shown in the language list (e.g. Български)."
+      },
+      {
+        "type": "text",
+        "id": "cross_market_language_iso",
+        "label": "Language ISO code",
+        "info": "Two-letter code used for hreflang/lang attributes (e.g. bg)."
+      },
+      {
+        "type": "text",
+        "id": "cross_market_host_match",
+        "label": "External market host",
+        "info": "Hostname of the external market (e.g. northfinder.bg). Used to hide the link when the visitor is already on that market.",
+        "default": "northfinder.bg"
       }
     ]
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1558,7 +1558,11 @@
     "settings": [
       {
         "type": "paragraph",
-        "content": "Adds an extra entry to the language selector that links to a separate Shopify Markets instance (different domain). Use when a language lives on its own market/domain (e.g., Bulgarian on northfinder.bg) and should still be discoverable from the language picker."
+        "content": "Adds an extra entry to the language selector that links to a separate Shopify Markets instance on a different domain. Same theme serves both markets: on the home market it shows the External entry, on the external market (matched by host) it shows the Home entry instead."
+      },
+      {
+        "type": "header",
+        "content": "External market (shown on the home market)"
       },
       {
         "type": "url",
@@ -1581,8 +1585,29 @@
         "type": "text",
         "id": "cross_market_host_match",
         "label": "External market host",
-        "info": "Hostname of the external market (e.g. northfinder.bg). Used to hide the link when the visitor is already on that market.",
+        "info": "Hostname of the external market (e.g. northfinder.bg). When the visitor is on this host, the External entry is hidden and the Home entry is shown instead.",
         "default": "northfinder.bg"
+      },
+      {
+        "type": "header",
+        "content": "Home market (shown on the external market)"
+      },
+      {
+        "type": "url",
+        "id": "cross_market_home_url",
+        "label": "Home market URL"
+      },
+      {
+        "type": "text",
+        "id": "cross_market_home_label",
+        "label": "Display label",
+        "info": "Endonym shown in the language list (e.g. English)."
+      },
+      {
+        "type": "text",
+        "id": "cross_market_home_iso",
+        "label": "Language ISO code",
+        "info": "Two-letter code used for hreflang/lang attributes (e.g. en)."
       }
     ]
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1595,19 +1595,8 @@
       {
         "type": "url",
         "id": "cross_market_home_url",
-        "label": "Home market URL"
-      },
-      {
-        "type": "text",
-        "id": "cross_market_home_label",
-        "label": "Display label",
-        "info": "Endonym shown in the language list (e.g. English)."
-      },
-      {
-        "type": "text",
-        "id": "cross_market_home_iso",
-        "label": "Language ISO code",
-        "info": "Two-letter code used for hreflang/lang attributes (e.g. en)."
+        "label": "Home market URL",
+        "info": "When the visitor is on the external market host, all non-current language entries link to this URL instead of switching locale inside the external market."
       }
     ]
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1558,31 +1558,13 @@
     "settings": [
       {
         "type": "paragraph",
-        "content": "Adds an extra entry to the language selector that links to a separate Shopify Markets instance (different domain). Use when a language lives on its own market/domain (e.g., Bulgarian on northfinder.bg) and should still be discoverable from the language picker."
+        "content": "Appends extra entries to the language selector that link to other Shopify Markets instances on a different domain (e.g. Bulgarian on northfinder.bg, English on shop.northfinder.com). Create a menu in Online Store → Navigation with one link per external market, then pick it below. Each menu item's URL is the destination, the title is the display label. Entries whose URL host matches the current visitor's domain auto-hide to avoid self-linking."
       },
       {
-        "type": "url",
-        "id": "cross_market_language_url",
-        "label": "External market URL"
-      },
-      {
-        "type": "text",
-        "id": "cross_market_language_label",
-        "label": "Display label",
-        "info": "Endonym shown in the language list (e.g. Български)."
-      },
-      {
-        "type": "text",
-        "id": "cross_market_language_iso",
-        "label": "Language ISO code",
-        "info": "Two-letter code used for hreflang/lang attributes (e.g. bg)."
-      },
-      {
-        "type": "text",
-        "id": "cross_market_host_match",
-        "label": "External market host",
-        "info": "Hostname of the external market (e.g. northfinder.bg). Used to hide the link when the visitor is already on that market.",
-        "default": "northfinder.bg"
+        "type": "link_list",
+        "id": "cross_market_language_menu",
+        "label": "External markets menu",
+        "info": "Menu of links to other markets (e.g. \"cross-market-languages\"). Each item's title becomes the display label; the URL determines the destination and the host used for the self-link guard."
       }
     ]
   }

--- a/sections/ecom-69eb1f8f5ae781310c01bc86111-home.liquid
+++ b/sections/ecom-69eb1f8f5ae781310c01bc86111-home.liquid
@@ -553,7 +553,7 @@ html,body{margin:0;padding:0}
  var locale=(window.Shopify&&Shopify.locale)?Shopify.locale:'en';
  var isBG=(locale==='bg');
  var isDefault=(locale==='en');
- document.querySelectorAll('a[href*="shop.northfinder.com"]').forEach(function(a){
+ document.querySelectorAll('a[href*="shop.northfinder.com"]:not([data-external-market])').forEach(function(a){
  var h=a.getAttribute('href');
  if(!h)return;
  if(isBG){

--- a/sections/ecom-homepage-new-home.liquid
+++ b/sections/ecom-homepage-new-home.liquid
@@ -554,7 +554,7 @@ html,body{margin:0;padding:0}
  var locale=(window.Shopify&&Shopify.locale)?Shopify.locale:'en';
  var isBG=(locale==='bg');
  var isDefault=(locale==='en');
- document.querySelectorAll('a[href*="shop.northfinder.com"]').forEach(function(a){
+ document.querySelectorAll('a[href*="shop.northfinder.com"]:not([data-external-market])').forEach(function(a){
  var h=a.getAttribute('href');
  if(!h)return;
  if(isBG){

--- a/sections/ecom-homepagenew-home.liquid
+++ b/sections/ecom-homepagenew-home.liquid
@@ -547,7 +547,7 @@ html,body{margin:0;padding:0}
  var locale=(window.Shopify&&Shopify.locale)?Shopify.locale:'en';
  var isBG=(locale==='bg');
  var isDefault=(locale==='en');
- document.querySelectorAll('a[href*="shop.northfinder.com"]').forEach(function(a){
+ document.querySelectorAll('a[href*="shop.northfinder.com"]:not([data-external-market])').forEach(function(a){
  var h=a.getAttribute('href');
  if(!h)return;
  if(isBG){

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -41,37 +41,36 @@
           </a>
         </li>
       {%- endfor -%}
-      {%- liquid
-        assign cross_market_url = settings.cross_market_language_url
-        assign cross_market_label = settings.cross_market_language_label
-        assign cross_market_iso = settings.cross_market_language_iso
-        assign cross_market_host = settings.cross_market_host_match
-        assign show_cross_market = false
-        if cross_market_url != blank and cross_market_label != blank
-          assign show_cross_market = true
-          if cross_market_host != blank and request.host contains cross_market_host
-            assign show_cross_market = false
-          endif
-        endif
-      -%}
-      {%- if show_cross_market -%}
-        <li class="disclosure__item disclosure__item--external" tabindex="-1">
-          <a
-            class="link link--text disclosure__link caption-large focus-inset"
-            href="{{ cross_market_url }}"
-            {% if cross_market_iso != blank %}
-              hreflang="{{ cross_market_iso }}"
-              lang="{{ cross_market_iso }}"
-            {% endif %}
-            rel="alternate"
-            data-external-market="true"
-          >
-            <span class="visibility-hidden">
-              {{- 'icon-checkmark.svg' | inline_asset_content -}}
-            </span>
-            <span>{{ cross_market_label | capitalize }}</span>
-          </a>
-        </li>
+      {%- if settings.cross_market_language_menu != blank -%}
+        {%- assign current_host = request.host | downcase -%}
+        {%- for link in settings.cross_market_language_menu.links -%}
+          {%- liquid
+            assign link_url = link.url | default: ''
+            assign link_host = link_url | split: '://' | last | split: '/' | first | downcase
+            assign show_link = true
+            if link_url == blank
+              assign show_link = false
+            endif
+            if link_host != blank and link_host == current_host
+              assign show_link = false
+            endif
+          -%}
+          {%- if show_link -%}
+            <li class="disclosure__item disclosure__item--external" tabindex="-1">
+              <a
+                class="link link--text disclosure__link caption-large focus-inset"
+                href="{{ link_url }}"
+                rel="alternate"
+                data-external-market="true"
+              >
+                <span class="visibility-hidden">
+                  {{- 'icon-checkmark.svg' | inline_asset_content -}}
+                </span>
+                <span>{{ link.title }}</span>
+              </a>
+            </li>
+          {%- endif -%}
+        {%- endfor -%}
       {%- endif -%}
     </ul>
   </div>

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -41,36 +41,37 @@
           </a>
         </li>
       {%- endfor -%}
-      {%- if settings.cross_market_language_menu != blank -%}
-        {%- assign current_host = request.host | downcase -%}
-        {%- for link in settings.cross_market_language_menu.links -%}
-          {%- liquid
-            assign link_url = link.url | default: ''
-            assign link_host = link_url | split: '://' | last | split: '/' | first | downcase
-            assign show_link = true
-            if link_url == blank
-              assign show_link = false
-            endif
-            if link_host != blank and link_host == current_host
-              assign show_link = false
-            endif
-          -%}
-          {%- if show_link -%}
-            <li class="disclosure__item disclosure__item--external" tabindex="-1">
-              <a
-                class="link link--text disclosure__link caption-large focus-inset"
-                href="{{ link_url }}"
-                rel="alternate"
-                data-external-market="true"
-              >
-                <span class="visibility-hidden">
-                  {{- 'icon-checkmark.svg' | inline_asset_content -}}
-                </span>
-                <span>{{ link.title }}</span>
-              </a>
-            </li>
-          {%- endif -%}
-        {%- endfor -%}
+      {%- liquid
+        assign cross_market_url = settings.cross_market_language_url
+        assign cross_market_label = settings.cross_market_language_label
+        assign cross_market_iso = settings.cross_market_language_iso
+        assign cross_market_host = settings.cross_market_host_match
+        assign show_cross_market = false
+        if cross_market_url != blank and cross_market_label != blank
+          assign show_cross_market = true
+          if cross_market_host != blank and request.host contains cross_market_host
+            assign show_cross_market = false
+          endif
+        endif
+      -%}
+      {%- if show_cross_market -%}
+        <li class="disclosure__item disclosure__item--external" tabindex="-1">
+          <a
+            class="link link--text disclosure__link caption-large focus-inset"
+            href="{{ cross_market_url }}"
+            {% if cross_market_iso != blank %}
+              hreflang="{{ cross_market_iso }}"
+              lang="{{ cross_market_iso }}"
+            {% endif %}
+            rel="alternate"
+            data-external-market="true"
+          >
+            <span class="visibility-hidden">
+              {{- 'icon-checkmark.svg' | inline_asset_content -}}
+            </span>
+            <span>{{ cross_market_label | capitalize }}</span>
+          </a>
+        </li>
       {%- endif -%}
     </ul>
   </div>

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -5,6 +5,14 @@
     - localPosition: pass in the position in which the form is coming up to create specific IDs
 {%- endcomment -%}
 
+{%- liquid
+  assign on_external_market = false
+  if settings.cross_market_host_match != blank and request.host contains settings.cross_market_host_match
+    assign on_external_market = true
+  endif
+  assign override_url = settings.cross_market_home_url
+-%}
+
 <div class="disclosure">
   <button
     type="button"
@@ -19,16 +27,28 @@
   <div class="disclosure__list-wrapper language-selector" hidden>
     <ul id="{{ localPosition }}List" role="list" class="disclosure__list list-unstyled">
       {%- for language in localization.available_languages -%}
-        <li class="disclosure__item" tabindex="-1">
+        {%- liquid
+          assign is_override = false
+          if on_external_market and override_url != blank and language.iso_code != localization.language.iso_code
+            assign is_override = true
+          endif
+        -%}
+        <li class="disclosure__item{% if is_override %} disclosure__item--external{% endif %}" tabindex="-1">
           <a
             class="link link--text disclosure__link caption-large focus-inset"
-            href="#"
+            {% if is_override -%}
+              href="{{ override_url }}"
+              rel="alternate"
+              data-external-market="true"
+            {%- else -%}
+              href="#"
+              data-value="{{ language.iso_code }}"
+            {%- endif %}
             hreflang="{{ language.iso_code }}"
             lang="{{ language.iso_code }}"
             {% if language.iso_code == localization.language.iso_code %}
               aria-current="true"
             {% endif %}
-            data-value="{{ language.iso_code }}"
           >
             <span
               {% if language.iso_code != localization.language.iso_code %}
@@ -42,32 +62,22 @@
         </li>
       {%- endfor -%}
       {%- liquid
-        assign on_external_market = false
-        if settings.cross_market_host_match != blank and request.host contains settings.cross_market_host_match
-          assign on_external_market = true
-        endif
-        if on_external_market
-          assign extra_url = settings.cross_market_home_url
-          assign extra_label = settings.cross_market_home_label
-          assign extra_iso = settings.cross_market_home_iso
-        else
-          assign extra_url = settings.cross_market_language_url
-          assign extra_label = settings.cross_market_language_label
-          assign extra_iso = settings.cross_market_language_iso
-        endif
-        assign show_extra = false
-        if extra_url != blank and extra_label != blank
-          assign show_extra = true
+        assign append_url = settings.cross_market_language_url
+        assign append_label = settings.cross_market_language_label
+        assign append_iso = settings.cross_market_language_iso
+        assign show_append = false
+        if append_url != blank and append_label != blank and on_external_market == false
+          assign show_append = true
         endif
       -%}
-      {%- if show_extra -%}
+      {%- if show_append -%}
         <li class="disclosure__item disclosure__item--external" tabindex="-1">
           <a
             class="link link--text disclosure__link caption-large focus-inset"
-            href="{{ extra_url }}"
-            {% if extra_iso != blank %}
-              hreflang="{{ extra_iso }}"
-              lang="{{ extra_iso }}"
+            href="{{ append_url }}"
+            {% if append_iso != blank %}
+              hreflang="{{ append_iso }}"
+              lang="{{ append_iso }}"
             {% endif %}
             rel="alternate"
             data-external-market="true"
@@ -75,7 +85,7 @@
             <span class="visibility-hidden">
               {{- 'icon-checkmark.svg' | inline_asset_content -}}
             </span>
-            <span>{{ extra_label | capitalize }}</span>
+            <span>{{ append_label | capitalize }}</span>
           </a>
         </li>
       {%- endif -%}

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -6,11 +6,12 @@
 {%- endcomment -%}
 
 {%- liquid
+  assign cross_market_host_match = settings.cross_market_host_match | strip
   assign on_external_market = false
-  if settings.cross_market_host_match != blank and request.host contains settings.cross_market_host_match
+  if cross_market_host_match != blank and request.host contains cross_market_host_match
     assign on_external_market = true
   endif
-  assign override_url = settings.cross_market_home_url
+  assign override_url = settings.cross_market_home_url | strip
 -%}
 
 <div class="disclosure">
@@ -32,12 +33,22 @@
           if on_external_market and override_url != blank and language.iso_code != localization.language.iso_code
             assign is_override = true
           endif
+          assign override_target = override_url
+          if is_override
+            assign override_base = override_url | split: '?' | first | split: '#' | first
+            assign last_char = override_base | slice: -1
+            if last_char == '/'
+              assign override_target = override_base | append: language.iso_code | append: '/'
+            else
+              assign override_target = override_base | append: '/' | append: language.iso_code | append: '/'
+            endif
+          endif
         -%}
         <li class="disclosure__item{% if is_override %} disclosure__item--external{% endif %}" tabindex="-1">
           <a
             class="link link--text disclosure__link caption-large focus-inset"
             {% if is_override -%}
-              href="{{ override_url }}"
+              href="{{ override_target }}"
               rel="alternate"
               data-external-market="true"
             {%- else -%}
@@ -62,9 +73,9 @@
         </li>
       {%- endfor -%}
       {%- liquid
-        assign append_url = settings.cross_market_language_url
-        assign append_label = settings.cross_market_language_label
-        assign append_iso = settings.cross_market_language_iso
+        assign append_url = settings.cross_market_language_url | strip
+        assign append_label = settings.cross_market_language_label | strip
+        assign append_iso = settings.cross_market_language_iso | strip
         assign show_append = false
         if append_url != blank and append_label != blank and on_external_market == false
           assign show_append = true

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -42,26 +42,32 @@
         </li>
       {%- endfor -%}
       {%- liquid
-        assign cross_market_url = settings.cross_market_language_url
-        assign cross_market_label = settings.cross_market_language_label
-        assign cross_market_iso = settings.cross_market_language_iso
-        assign cross_market_host = settings.cross_market_host_match
-        assign show_cross_market = false
-        if cross_market_url != blank and cross_market_label != blank
-          assign show_cross_market = true
-          if cross_market_host != blank and request.host contains cross_market_host
-            assign show_cross_market = false
-          endif
+        assign on_external_market = false
+        if settings.cross_market_host_match != blank and request.host contains settings.cross_market_host_match
+          assign on_external_market = true
+        endif
+        if on_external_market
+          assign extra_url = settings.cross_market_home_url
+          assign extra_label = settings.cross_market_home_label
+          assign extra_iso = settings.cross_market_home_iso
+        else
+          assign extra_url = settings.cross_market_language_url
+          assign extra_label = settings.cross_market_language_label
+          assign extra_iso = settings.cross_market_language_iso
+        endif
+        assign show_extra = false
+        if extra_url != blank and extra_label != blank
+          assign show_extra = true
         endif
       -%}
-      {%- if show_cross_market -%}
+      {%- if show_extra -%}
         <li class="disclosure__item disclosure__item--external" tabindex="-1">
           <a
             class="link link--text disclosure__link caption-large focus-inset"
-            href="{{ cross_market_url }}"
-            {% if cross_market_iso != blank %}
-              hreflang="{{ cross_market_iso }}"
-              lang="{{ cross_market_iso }}"
+            href="{{ extra_url }}"
+            {% if extra_iso != blank %}
+              hreflang="{{ extra_iso }}"
+              lang="{{ extra_iso }}"
             {% endif %}
             rel="alternate"
             data-external-market="true"
@@ -69,7 +75,7 @@
             <span class="visibility-hidden">
               {{- 'icon-checkmark.svg' | inline_asset_content -}}
             </span>
-            <span>{{ cross_market_label | capitalize }}</span>
+            <span>{{ extra_label | capitalize }}</span>
           </a>
         </li>
       {%- endif -%}


### PR DESCRIPTION
## Summary

Follow-ups to PR #10 (already merged). Found three real issues during deeper edge-case verification on the live `northfinder.bg` market:

1. **`nfFixLinks` rewriter swallowed our external links** (commit 8843d172). Three homepage section variants ship with an IIFE that rewrites every `shop.northfinder.com` anchor depending on the active locale. On BG visitors it prepended `northfinder.bg/en/`, on other locales it inserted a `/<locale>/` segment. That mutated our cross-market language entries so clicking English/Hrvatski/Deutsch/Slovenščina on `northfinder.bg` looped back to `northfinder.bg/en/<iso>/` instead of `shop.northfinder.com/<iso>/`. Narrowed the rewriter's selector to `:not([data-external-market])` so opt-out entries are left alone.

2. **Override URL ignored the destination locale** (commit a2b9840a). When the BG visitor clicked Hrvatski we used to drop them on the bare EUR homepage, but `hreflang="hr"` promised Croatian content. The snippet now builds locale-aware URLs (`/hr/`, `/de/`, `/sl/`) so SEO and UX line up. Also added a `strip` filter on every cross-market setting so accidental whitespace in the Theme Editor doesn't silently disable the feature.

3. **2-way override is the actual customer ask** (commits c51cde39, 2d19fd6f, 333d561b reverts a linklist refactor we no longer need). On the external market every non-current language entry redirects to the home market URL instead of switching locale inside the external market. Only the current locale (Bulgarian on `.bg`) stays as a no-op marker.

## Verification on real `northfinder.bg`

Used `https://northfinder.bg/?preview_theme_id=199891878220&_fd=0&pb=0` (preview cookie set via admin "Preview store"):

| Surface | Result |
|---|---|
| Homepage footer language list | Български (current), English/Hrvatski/Deutsch/Slovenščina → `https://shop.northfinder.com/<iso>/` |
| Collection page (`/collections/all`) | Same |
| Announcement bar + mobile drawer | Same (3 placements × 4 entries = 12 external links) |
| Click Deutsch | Navigates to `https://shop.northfinder.com/de/` with `<html lang="de">` |

EUR side regression-tested via share-preview: appended Български entry still works.

Edge cases swept on draft theme (#199891878220):
- Empty settings → feature inert
- URL set but label/iso missing → entry not rendered
- `home_url` empty on BG side → no override applied
- Whitespace-padded settings → handled by `strip`
- Substring host_match like `.bg` → no false positive on `shop.northfinder.com`
- Cart + collection pages render correctly
- Mobile drawer toggle unaffected
- SEO `<head>` hreflang tags coexist with our inline ones

## Files

- `snippets/language-localization.liquid` — override + locale-aware path build + strip filter
- `config/settings_data.json`, `config/settings_schema.json` — drop unused home_label/home_iso, info copy update
- `sections/ecom-homepagenew-home.liquid`, `sections/ecom-homepage-new-home.liquid`, `sections/ecom-69eb1f8f5ae781310c01bc86111-home.liquid` — rewriter exclusion selector

## Test plan

1. Pull this branch onto a draft theme.
2. Visit the EUR storefront — confirm Български appended in announce/footer/drawer and clicking goes to `northfinder.bg`.
3. Visit the BG storefront — confirm Български is the active locale, the other four entries point to `shop.northfinder.com/<iso>/`, and clicking one lands on the correct locale page on the EUR market.
4. Sanity check on cart + collection pages on both sides.
