### PR TITLE
fix(localization): skip locale prefix for home market default language

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -137,6 +137,7 @@
     "cross_market_language_iso": "bg",
     "cross_market_host_match": "northfinder.bg",
     "cross_market_home_url": "https://shop.northfinder.com/",
+    "cross_market_home_default_iso": "en",
     "sections": {
       "main-password-header": {
         "type": "main-password-header",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1597,6 +1597,13 @@
         "id": "cross_market_home_url",
         "label": "Home market URL",
         "info": "When the visitor is on the external market host, all non-current language entries link to this URL instead of switching locale inside the external market."
+      },
+      {
+        "type": "text",
+        "id": "cross_market_home_default_iso",
+        "label": "Home market default language ISO",
+        "info": "ISO code of the default language on the home market (e.g. 'en'). The entry for this language links to the root URL without a locale prefix; other languages append /<iso>/.",
+        "default": "en"
       }
     ]
   }

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -12,6 +12,7 @@
     assign on_external_market = true
   endif
   assign override_url = settings.cross_market_home_url | strip
+  assign override_default_iso = settings.cross_market_home_default_iso | strip | downcase
 -%}
 
 <div class="disclosure">
@@ -37,10 +38,19 @@
           if is_override
             assign override_base = override_url | split: '?' | first | split: '#' | first
             assign last_char = override_base | slice: -1
-            if last_char == '/'
-              assign override_target = override_base | append: language.iso_code | append: '/'
+            assign lang_iso_lower = language.iso_code | downcase
+            if override_default_iso != blank and lang_iso_lower == override_default_iso
+              if last_char == '/'
+                assign override_target = override_base
+              else
+                assign override_target = override_base | append: '/'
+              endif
             else
-              assign override_target = override_base | append: '/' | append: language.iso_code | append: '/'
+              if last_char == '/'
+                assign override_target = override_base | append: language.iso_code | append: '/'
+              else
+                assign override_target = override_base | append: '/' | append: language.iso_code | append: '/'
+              endif
             endif
           endif
         -%}


### PR DESCRIPTION
## Summary

Follow-up to PR #11. On the BG market the English language entry was building `https://shop.northfinder.com/en/` to match the other locale entries, but English is the default locale on the EUR market and its canonical URL is the root, not `/en/`. Search engines and link previews treat the prefixed URL as a secondary canonical and the redirect chain is unnecessary.

## Change

Adds a `cross_market_home_default_iso` setting (default `en`) read by the snippet. When the iterated language matches that ISO, the override link stays on the bare home URL; every other language continues to append `/<iso>/`.

```liquid
if override_default_iso != blank and lang_iso_lower == override_default_iso
  # root URL, no locale segment
else
  # append /<iso>/
endif
```

`settings_data.json` is pre-seeded with `"en"` so the feature ships with the correct behavior. Merchants whose home-market default language is not English (e.g. a future RO or PL store) can override the setting in the Theme Editor.

## Verification on real `northfinder.bg`

Used `https://northfinder.bg/?preview_theme_id=199891878220` with the draft theme active. Footer/announcement/drawer all now render:

| Language | href |
|---|---|
| Български (current) | no-op |
| **English** | `https://shop.northfinder.com/` |
| Hrvatski | `https://shop.northfinder.com/hr/` |
| Deutsch | `https://shop.northfinder.com/de/` |
| Slovenščina | `https://shop.northfinder.com/sl/` |

Click on English from BG lands on `https://shop.northfinder.com/` with `<html lang="en">` — the canonical EUR home, no redirect chain.
