### PR TITLE
fix(header): hide cashback icon for guests

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -167,9 +167,11 @@
         endif
       -%}
 
-      <a href="{{ routes.cart_url }}" class="header__icon link px-3 focus-inset ">
-        <span class="svg-wrapper [&_svg]:size-[1.625rem]">{{ 'icon-currency.svg' | inline_asset_content }}</span>
-      </a>
+      {%- if customer -%}
+        <a href="{{ routes.cart_url }}" class="header__icon link px-3 focus-inset ">
+          <span class="svg-wrapper [&_svg]:size-[1.625rem]">{{ 'icon-currency.svg' | inline_asset_content }}</span>
+        </a>
+      {%- endif -%}
 
       {%- for block in section.blocks -%}
         {%- case block.type -%}


### PR DESCRIPTION
## Issue
Cashback icon was visible on mobile and desktop for all countries even when the user was not logged in.

## Fix
Wrap the `icon-currency.svg` link in `sections/header.liquid` with `{% if customer %}` so it only renders when a customer is logged in. Since `customer` is `nil` for guests in every storefront context, this hides the icon on all markets / breakpoints.

## Verification
- Pushed to draft theme `QA-cashback-hide-260626-1114` on `sportfinder-international`.
- Curled `shop.northfinder.com?preview_theme_id=…` as a guest:
  - `icon-currency` occurrences: **0**
  - Account & cart icons still render.
- Validated with `shopify-liquid` skill (`scripts/validate.mjs`) — no new errors.
- Draft theme deleted after verification.