### PR TITLE
refactor(metafields): switch product features namespace to custom_features

### DIFF
--- a/schemas/size-fit-metafields-schema.json
+++ b/schemas/size-fit-metafields-schema.json
@@ -122,7 +122,7 @@
     "bodyMeasurements": {
       "type": "object",
       "title": "Body Measurements Metafield (size_fit.body_measurements)",
-      "description": "Standard body measurements for size guide. Gender is obtained from product.metafields.features.gender",
+      "description": "Standard body measurements for size guide. Gender is obtained from product.metafields.custom_features.gender",
       "patternProperties": {
         "^(XXS|XS|S|M|L|XL|XXL|3XL|4XL)$": {
           "$ref": "#/definitions/sizeInfo"
@@ -135,7 +135,7 @@
     "productMeasurements": {
       "type": "object",
       "title": "Product Measurements Metafield (size_fit.measurements)",
-      "description": "Product-specific measurements for garments. Product category is obtained from product.metafields.features.kind",
+      "description": "Product-specific measurements for garments. Product category is obtained from product.metafields.custom_features.kind",
       "patternProperties": {
         "^(XXS|XS|S|M|L|XL|XXL|3XL|4XL)$": {
           "$ref": "#/definitions/sizeChart"

--- a/sections/main-product-parfums.liquid
+++ b/sections/main-product-parfums.liquid
@@ -81,8 +81,8 @@
               {% render 'discount-badge', product: product, badge_class: 'product-discount-badge' %}
 
               <!-- Product tags from metafields -->
-              {%- if product.metafields.features.extra.value -%}
-                {%- for extra_tag in product.metafields.features.extra.value -%}
+              {%- if product.metafields.custom_features.extra.value -%}
+                {%- for extra_tag in product.metafields.custom_features.extra.value -%}
                   <span class="text-medium text-[13px] leading-4 uppercase text-[#4d4d4d] border border-[#ccc] px-2 py-1 rounded-[2px]">
                     {{- extra_tag.name -}}
                   </span>
@@ -90,8 +90,8 @@
               {%- endif -%}
 
               <!-- Promotion metafield -->
-              {%- if product.metafields.features.promotion.value -%}
-                {%- for promotion in product.metafields.features.promotion.value -%}
+              {%- if product.metafields.custom_features.promotion.value -%}
+                {%- for promotion in product.metafields.custom_features.promotion.value -%}
                   <span class="text-medium text-[13px] leading-4 uppercase text-[#4d4d4d] border border-[#ccc] px-2 py-1 rounded-[2px]">
                     {{- promotion.name -}}
                   </span>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -80,8 +80,8 @@
               {% render 'discount-badge', product: product, badge_class: 'product-discount-badge' %}
 
               <!-- Product tags from metafields -->
-              {%- if product.metafields.features.extra.value -%}
-                {%- for extra_tag in product.metafields.features.extra.value -%}
+              {%- if product.metafields.custom_features.extra.value -%}
+                {%- for extra_tag in product.metafields.custom_features.extra.value -%}
                   <span class="text-medium text-[13px] leading-4 uppercase text-[#4d4d4d] border border-[#ccc] px-2 py-1 rounded-[2px]">
                     {{- extra_tag.name -}}
                   </span>
@@ -89,8 +89,8 @@
               {%- endif -%}
 
               <!-- Promotion metafield -->
-              {%- if product.metafields.features.promotion.value -%}
-                {%- for promotion in product.metafields.features.promotion.value -%}
+              {%- if product.metafields.custom_features.promotion.value -%}
+                {%- for promotion in product.metafields.custom_features.promotion.value -%}
                   <span class="text-medium text-[13px] leading-4 uppercase text-[#4d4d4d] border border-[#ccc] px-2 py-1 rounded-[2px]">
                     {{- promotion.name -}}
                   </span>
@@ -626,7 +626,7 @@
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-y-8 gap-x-20">
-          {% if product.metafields.features.size > 0 %}
+          {% if product.metafields.custom_features.size > 0 %}
             {% comment %}
               Pre-filter features to display, then sort by metaobject `position` ascending
               (lower position = shown first, matching the backend PIM convention).
@@ -643,7 +643,7 @@
                 (Construction / Storage / Adjustability) — see product-features-details snippet.
               {%- endcomment -%}
               {%- assign features_details_keys = 'hood,collar,sleeve,shoulders,inside,ventilation,pockets,zipper,hydration,waist,knee,bottom_legs,back,hips' | split: ',' -%}
-              {% for metafield in product.metafields.features %}
+              {% for metafield in product.metafields.custom_features %}
                 {% assign key = metafield | first %}
                 {% assign arr_values = metafield | last %}
                 {%- assign is_features_details_key = false -%}
@@ -690,13 +690,13 @@
                     {% for entry in sorted_entries %}
                       {% assign entry_parts = entry | split: '|' %}
                       {% assign key = entry_parts | last %}
-                      {% assign arr_values = product.metafields.features[key] %}
+                      {% assign arr_values = product.metafields.custom_features[key] %}
                       {% comment %}
                         Skip vapor_permeability when it is paired with water_column on the
                         same row (rendered together below for the water_column entry).
                       {% endcomment %}
                       {% assign is_paired_vapor = false %}
-                      {% if key == 'vapor_permeability_g_m2_24hr' and product.metafields.features.water_column_wp_mm.value != blank %}
+                      {% if key == 'vapor_permeability_g_m2_24hr' and product.metafields.custom_features.water_column_wp_mm.value != blank %}
                         {% assign is_paired_vapor = true %}
                       {% endif %}
                       {% if arr_values.value != blank and is_paired_vapor == false %}
@@ -750,7 +750,7 @@
                             Pair vapor_permeability inline with water_column when both
                             are present, per customer feedback (Tab 1, #7 + #8).
                           {%- endcomment -%}
-                          {% if key == 'water_column_wp_mm' and product.metafields.features.vapor_permeability_g_m2_24hr.value != blank %}
+                          {% if key == 'water_column_wp_mm' and product.metafields.custom_features.vapor_permeability_g_m2_24hr.value != blank %}
                             {%- liquid
                               assign vapor_obj = null
                               for feature in shop.metaobjects.product_feature.values
@@ -766,7 +766,7 @@
                               {{- vapor_label -}}
                               :</strong
                             >
-                            {% assign vapor_items = product.metafields.features.vapor_permeability_g_m2_24hr.value | map: 'name' %}
+                            {% assign vapor_items = product.metafields.custom_features.vapor_permeability_g_m2_24hr.value | map: 'name' %}
                             {% assign vapor_text = '' %}
                             {% for item in vapor_items %}
                               {% if forloop.first %}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -26,8 +26,8 @@
         {% render 'discount-badge', product: card_product %}
 
         <!-- Product tags from metafields (max 3) -->
-        {%- if card_product.metafields.features.extra.value -%}
-          {%- for extra_tag in card_product.metafields.features.extra.value -%}
+        {%- if card_product.metafields.custom_features.extra.value -%}
+          {%- for extra_tag in card_product.metafields.custom_features.extra.value -%}
             {%- if tag_count < 3 -%}
               <span class="text-medium text-[13px] leading-4 uppercase text-[#4d4d4d] border border-[#ccc] px-2 py-1 rounded-[2px] flex-shrink-0">
                 {{- extra_tag.name -}}
@@ -38,8 +38,8 @@
         {%- endif -%}
 
         <!-- Promotion metafield -->
-        {%- if card_product.metafields.features.promotion.value -%}
-          {%- for promotion in card_product.metafields.features.promotion.value -%}
+        {%- if card_product.metafields.custom_features.promotion.value -%}
+          {%- for promotion in card_product.metafields.custom_features.promotion.value -%}
             {%- if tag_count < 3 -%}
               <span class="text-medium text-[13px] leading-4 uppercase text-[#4d4d4d] border border-[#ccc] px-2 py-1 rounded-[2px] flex-shrink-0">
                 {{- promotion.name -}}

--- a/snippets/feature-dot-scale.liquid
+++ b/snippets/feature-dot-scale.liquid
@@ -4,11 +4,11 @@
   3-level scale (low / medium / high).
 
   Accepts:
-  - feature_values: {Array} product.metafields.features.<key>.value
+  - feature_values: {Array} product.metafields.custom_features.<key>.value
                     (list of metaobject references — first item is used)
 
   Usage:
-  {% render 'feature-dot-scale', feature_values: product.metafields.features.waterproofness.value %}
+  {% render 'feature-dot-scale', feature_values: product.metafields.custom_features.waterproofness.value %}
 {% endcomment %}
 
 {%- assign level = 0 -%}

--- a/snippets/nf-flow-series-badge.liquid
+++ b/snippets/nf-flow-series-badge.liquid
@@ -1,6 +1,6 @@
 {% comment %}
   Renders NF Flow™ Series brand badge(s) above the Parameters section.
-  Data source: product.metafields.features.nf_flow_series — a list of
+  Data source: product.metafields.custom_features.nf_flow_series — a list of
   `product_feature_preset` metaobjects (e.g., "PATH Flow™ Series", "PeakFlow Series").
 
   Renders nothing when the metafield is blank.
@@ -12,9 +12,9 @@
   {% render 'nf-flow-series-badge', product: product %}
 {% endcomment %}
 
-{%- if product.metafields.features.nf_flow_series.value != blank -%}
+{%- if product.metafields.custom_features.nf_flow_series.value != blank -%}
   <div class="nf-series-badge-group flex flex-wrap gap-2 mb-4">
-    {%- for series in product.metafields.features.nf_flow_series.value -%}
+    {%- for series in product.metafields.custom_features.nf_flow_series.value -%}
       {%- assign series_name = series.name | metafield_text -%}
       {%- if series_name != blank -%}
         <div class="nf-series-badge inline-flex items-center px-4 py-2 text-white text-sm font-bold leading-4 uppercase tracking-wider rounded-sm" style="background-color:#0F0F0F">

--- a/snippets/product-benefit.liquid
+++ b/snippets/product-benefit.liquid
@@ -16,8 +16,8 @@
 
 {% comment %} Use system.handle for language-independent comparison {% endcomment %}
 {% assign breathability_name = '' %}
-{% if product.metafields.features.breathability.value %}
-  {% for breathability_obj in product.metafields.features.breathability.value %}
+{% if product.metafields.custom_features.breathability.value %}
+  {% for breathability_obj in product.metafields.custom_features.breathability.value %}
     {% assign breathability_name = breathability_obj.system.handle %}
     {% break %}
   {% endfor %}
@@ -44,8 +44,8 @@
 
 {% comment %} Use system.handle for language-independent comparison {% endcomment %}
 {% assign elasticity_name = '' %}
-{% if product.metafields.features.elasticity.value %}
-  {% for elasticity_obj in product.metafields.features.elasticity.value %}
+{% if product.metafields.custom_features.elasticity.value %}
+  {% for elasticity_obj in product.metafields.custom_features.elasticity.value %}
     {% assign elasticity_name = elasticity_obj.system.handle %}
     {% break %}
   {% endfor %}
@@ -72,8 +72,8 @@
 
 {% comment %} Use system.handle for language-independent comparison {% endcomment %}
 {% assign windproofness_name = '' %}
-{% if product.metafields.features.windproofness.value %}
-  {% for windproofness_obj in product.metafields.features.windproofness.value %}
+{% if product.metafields.custom_features.windproofness.value %}
+  {% for windproofness_obj in product.metafields.custom_features.windproofness.value %}
     {% assign windproofness_name = windproofness_obj.system.handle %}
     {% break %}
   {% endfor %}
@@ -100,8 +100,8 @@
 
 {% comment %} Use system.handle for language-independent comparison {% endcomment %}
 {% assign warmth_name = '' %}
-{% if product.metafields.features.warmth.value %}
-  {% for warmth_obj in product.metafields.features.warmth.value %}
+{% if product.metafields.custom_features.warmth.value %}
+  {% for warmth_obj in product.metafields.custom_features.warmth.value %}
     {% assign warmth_name = warmth_obj.system.handle %}
     {% break %}
   {% endfor %}

--- a/snippets/product-features-details.liquid
+++ b/snippets/product-features-details.liquid
@@ -44,7 +44,7 @@
     {%- comment -%} ============ CONSTRUCTION ============ {%- endcomment -%}
     {%- assign construction_entries = '' -%}
     {%- for k in construction_keys -%}
-      {%- assign mf = product.metafields.features[k] -%}
+      {%- assign mf = product.metafields.custom_features[k] -%}
       {%- if mf.value != blank -%}
         {%- assign feature_obj = null -%}
         {%- assign k_dash = k | replace: '_', '-' -%}
@@ -74,8 +74,8 @@
     {%- endcomment -%}
     {%- assign storage_entries = '' -%}
 
-    {%- assign pockets_mf = product.metafields.features.pockets -%}
-    {%- assign zipper_mf = product.metafields.features.zipper -%}
+    {%- assign pockets_mf = product.metafields.custom_features.pockets -%}
+    {%- assign zipper_mf = product.metafields.custom_features.zipper -%}
     {%- assign has_pockets = false -%}
     {%- assign has_zipper = false -%}
     {%- if pockets_mf.value != blank -%}{%- assign has_pockets = true -%}{%- endif -%}
@@ -98,7 +98,7 @@
       {%- assign storage_entries = pair_padded | append: '|__pockets_zipper__' -%}
     {%- endif -%}
 
-    {%- assign hydration_mf = product.metafields.features.hydration -%}
+    {%- assign hydration_mf = product.metafields.custom_features.hydration -%}
     {%- if hydration_mf.value != blank -%}
       {%- assign hyd_pos = 9999 -%}
       {%- for feature in shop.metaobjects.product_feature.values -%}
@@ -119,7 +119,7 @@
     {%- comment -%} ============ ADJUSTABILITY ============ {%- endcomment -%}
     {%- assign adjustability_entries = '' -%}
     {%- for k in adjustability_keys -%}
-      {%- assign mf = product.metafields.features[k] -%}
+      {%- assign mf = product.metafields.custom_features[k] -%}
       {%- if mf.value != blank -%}
         {%- assign feature_obj = null -%}
         {%- assign k_dash = k | replace: '_', '-' -%}
@@ -173,7 +173,7 @@
           {%- for entry in construction_sorted -%}
             {%- assign entry_parts = entry | split: '|' -%}
             {%- assign key = entry_parts | last -%}
-            {%- assign arr_values = product.metafields.features[key] -%}
+            {%- assign arr_values = product.metafields.custom_features[key] -%}
             {%- assign feature_obj = null -%}
             {%- assign key_dash = key | replace: '_', '-' -%}
             {%- for feature in shop.metaobjects.product_feature.values -%}
@@ -218,12 +218,12 @@
             {%- assign key = entry_parts | last -%}
 
             {%- if key == '__pockets_zipper__' -%}
-              {%- assign pockets_count = product.metafields.features.pockets.value | size -%}
+              {%- assign pockets_count = product.metafields.custom_features.pockets.value | size -%}
               {%- assign pockets_text = '' -%}
               {%- if pockets_count > 0 -%}
                 {%- assign pockets_text = 'sections.main_product.features_details.pockets_with_count' | t: count: pockets_count -%}
               {%- endif -%}
-              {%- assign zipper_items = product.metafields.features.zipper.value | map: 'name' -%}
+              {%- assign zipper_items = product.metafields.custom_features.zipper.value | map: 'name' -%}
               {%- assign zipper_text = '' -%}
               {%- for item in zipper_items -%}
                 {%- if forloop.first -%}
@@ -249,7 +249,7 @@
                 </li>
               {%- endif -%}
             {%- else -%}
-              {%- assign arr_values = product.metafields.features[key] -%}
+              {%- assign arr_values = product.metafields.custom_features[key] -%}
               {%- assign feature_obj = null -%}
               {%- assign key_dash = key | replace: '_', '-' -%}
               {%- for feature in shop.metaobjects.product_feature.values -%}
@@ -292,7 +292,7 @@
           {%- for entry in adjustability_sorted -%}
             {%- assign entry_parts = entry | split: '|' -%}
             {%- assign key = entry_parts | last -%}
-            {%- assign arr_values = product.metafields.features[key] -%}
+            {%- assign arr_values = product.metafields.custom_features[key] -%}
             {%- assign feature_obj = null -%}
             {%- assign key_dash = key | replace: '_', '-' -%}
             {%- for feature in shop.metaobjects.product_feature.values -%}

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -262,8 +262,8 @@
       {%- if is_size_option -%}
         {%- comment -%} Check product kind to hide size-fit-button for scarfs {%- endcomment -%}
         {%- assign is_scarfs = false -%}
-        {%- if product.metafields.features.kind.value -%}
-          {%- for kind_item in product.metafields.features.kind.value -%}
+        {%- if product.metafields.custom_features.kind.value -%}
+          {%- for kind_item in product.metafields.custom_features.kind.value -%}
             {%- assign kind_system_handle = kind_item.system.handle -%}
             {%- if kind_system_handle == 'scarfs' -%}
               {%- assign is_scarfs = true -%}

--- a/snippets/size-fit-body-measurements.liquid
+++ b/snippets/size-fit-body-measurements.liquid
@@ -17,8 +17,8 @@
 {% assign gender_values = '' %}
 
 {% comment %} Check features.kind for shoes using system.handle for language-independent comparison {% endcomment %}
-{% if product.metafields.features.kind.value %}
-  {% for kind_item in product.metafields.features.kind.value %}
+{% if product.metafields.custom_features.kind.value %}
+  {% for kind_item in product.metafields.custom_features.kind.value %}
     {% assign kind_system_handle = kind_item.system.handle %}
     {% assign kind_values = kind_values | append: kind_system_handle | append: ',' %}
     {% if kind_system_handle == 'shoes' %}
@@ -28,8 +28,8 @@
 {% endif %}
 
 {% comment %} Check features.gender for men using system.handle for language-independent comparison {% endcomment %}
-{% if product.metafields.features.gender.value %}
-  {% for gender_item in product.metafields.features.gender.value %}
+{% if product.metafields.custom_features.gender.value %}
+  {% for gender_item in product.metafields.custom_features.gender.value %}
     {% assign gender_system_handle = gender_item.system.handle %}
     {% assign gender_values = gender_values | append: gender_system_handle | append: ',' %}
     {% if gender_system_handle == 'men' or gender_system_handle == 'man' %}

--- a/snippets/size-fit-modal.liquid
+++ b/snippets/size-fit-modal.liquid
@@ -23,7 +23,7 @@
     <div class="modal-header flex items-center justify-between p-4 md:p-6 border-b border-gray-200">
       {% comment %} Determine gender based on product metafield features.gender or default to Men's {% endcomment %}
       {% assign gender = 'size_guide.gender.mens' | t %}
-      {% assign gender_metafield = product.metafields.features.gender.value %}
+      {% assign gender_metafield = product.metafields.custom_features.gender.value %}
       {% if gender_metafield %}
         {% for gender_obj in gender_metafield %}
           {% comment %} Use system.handle for language-independent comparison {% endcomment %}

--- a/snippets/size-fit-product-measurements.liquid
+++ b/snippets/size-fit-product-measurements.liquid
@@ -210,8 +210,8 @@
   %}
   {% assign product_kind_handle = blank %}
 
-  {% if product.metafields.features.kind.value %}
-    {% for kind_item in product.metafields.features.kind.value %}
+  {% if product.metafields.custom_features.kind.value %}
+    {% for kind_item in product.metafields.custom_features.kind.value %}
       {% assign kind_system_handle = kind_item.system.handle %}
       {% if supported_categories contains kind_system_handle %}
         {% assign product_kind_handle = kind_system_handle %}


### PR DESCRIPTION
## Summary
Switch theme reads from `product.metafields.features.*` → `product.metafields.custom_features.*` everywhere the theme consumes them.

## Backend prerequisites — all DONE (verified for INTL)
| Item | Status |
|---|---|
| `custom_features.*` metafield definitions (74 keys) | ✅ all PUBLIC_READ |
| Product data backfilled to `custom_features.*` | ✅ |
| Metaobject entries publishable status | ✅ 100% ACTIVE (16 types) |
| Metaobject definitions `translatable.enabled` | ✅ 51/51 (needed for multi-locale INTL) |
| Smart collection rules re-pointed to `custom_features.*` | ✅ 37/37 rules across 4 keys (gender / type_of_gear / nf_flow_series / promotion) |
| Search & Discovery facet config re-pointed | ✅ 9/9 facets on `custom_features.*` |

## Theme scope (52 sites, 12 files)
- **11 Liquid files** (50 sites incl. bracket-access keys):
  - `snippets/`: `card-product.liquid`, `product-benefit.liquid`, `product-variant-picker.liquid`, `size-fit-{body,product}-measurements.liquid`, `size-fit-modal.liquid`, `feature-dot-scale.liquid`, `nf-flow-series-badge.liquid`, `product-features-details.liquid`
  - `sections/`: `main-product.liquid`, `main-product-parfums.liquid`
- **2 docstring lines** in `schemas/size-fit-metafields-schema.json`

## Verification on INTL draft theme (#201428402508)
- **PDP** `womens-trekking-1l-softshell-active-jacket-cori` — `#parameters-section` renders 6 rows (ACTIVITIES, SEASON, LAYERING, CUT, NAME OF MATERIAL, COMPOSITION) with values from `custom_features.*`.
- **Storefront collection facets** — 12 facet groups exposed, 9 on `custom_features.*`:
  - `custom_features.activities`=ski-touring → 110 products (vs 1246 unfiltered)
  - `custom_features.promotion`=eco-sale → 17 products
  - `custom_features.gender`=men → 599 products
  - Legacy `?filter.p.m.features.activities=<gid>` correctly no-op
- **Smart collections** — all 37 metafield rules bind `custom_features.*`, 0 collections empty, all product counts preserved through migration.

## Follow-up (post-merge)
- Publish theme #201428402508 to make INTL storefront use `custom_features.*` end-to-end.
- After live theme stable, backend can safely delete legacy `features.*` metafield definitions (75 keys) — no theme code, smart collection, or facet still binds them.

## Rollback
Backend keeps `features.*` in parallel until post-merge sign-off — revert this PR restores the previous namespace behavior on INTL immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
