### PR TITLE
fix(cart,account): use locale-aware URL for empty wishlist link

### DIFF
--- a/sections/main-cart-footer.liquid
+++ b/sections/main-cart-footer.liquid
@@ -22,7 +22,7 @@
   show-price
   product-options="dropdowns"
   move-to-cart
-  wishlist-empty-link="/collections/all"
+  wishlist-empty-link="{{ routes.all_products_collection_url }}"
 ></wishlist-page>
 {% comment %} <div
   class="gradient color-{{ section.settings.color_scheme }}{% if cart == empty %} is-empty{% endif %}"

--- a/snippets/account-tab-wishlist.liquid
+++ b/snippets/account-tab-wishlist.liquid
@@ -17,6 +17,6 @@
     show-price
     product-options="dropdowns"
     move-to-cart
-    wishlist-empty-link="/collections/all"
+    wishlist-empty-link="{{ routes.all_products_collection_url }}"
   ></wishlist-page>
 </div>


### PR DESCRIPTION
## Summary

The `wishlist-empty-link` on the cart footer and account wishlist tab was hardcoded to `/collections/all`, dropping the locale prefix when a buyer browses a non-primary locale (SL/CZ/RO). Empty-state CTA leaked to the default locale.

Switched to `{{ routes.all_products_collection_url }}` so Shopify prefixes the URL with the active locale. This matches the pattern already used elsewhere in the theme:

- `snippets/cart-drawer.liquid:45`
- `sections/main-cart-items.liquid:195,205`
- `sections/main-addresses.liquid:99`

## Files
- `sections/main-cart-footer.liquid:25`
- `snippets/account-tab-wishlist.liquid:20`

## Test plan
1. Browse `/sl/` locale on sportfinder-international.
2. Open cart drawer / cart page when wishlist is empty.
3. Click the empty-wishlist CTA — it should land on `/sl/collections/all`, not `/collections/all`.
4. Repeat on primary (`en`) locale to confirm no regression.

## Related
Discovered while auditing SL localization issues on product pages. Other reported issues (banner + section headings still in EN/DE, product card tags) are content translations registered via `translationsRegister` in Shopify Admin — no code change needed and already applied for the affected templates (`product.northkit.json`, `index.ecom-backup.json`).