### PR TITLE
feat(mega-menu): desktop mega menu matching Figma design

### DIFF
--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -3,13 +3,14 @@
 }
 
 .mega-menu__content {
+  background-color: rgb(var(--color-base-background));
   border-left: 0;
   border-radius: 0;
   border-right: 0;
   left: 0;
   overflow-y: auto;
-  padding-bottom: 2.25rem;
-  padding-top: 3rem;
+  padding-bottom: 0;
+  padding-top: 0;
   position: absolute;
   right: 0;
   top: 100%;
@@ -33,50 +34,141 @@
   transform: translateY(0);
 }
 
+/* Panel inner wrapper — max-width container (1600px, centered) is provided by .page-width */
+.mega-menu__inner {
+  --mega-menu-col-gap: 3.125rem; /* 50px between columns (Figma) */
+  --mega-menu-col-width: 12.5rem; /* 200px column (Figma) */
+  padding-top: 2rem; /* 32px */
+  padding-bottom: 2rem; /* 32px */
+}
+
+/* Column list — fixed-width columns, centered; wraps to a new row when there are
+   more columns than fit. Figma centers a row of 200px columns with 50px gaps. */
 .mega-menu__list {
-  background-color: rgb(var(--color-base-background));
+  /* All columns stay on a single centered row. --mega-menu-cols is set inline
+     from the menu's column count, so N items => N columns (no orphan row).
+     Columns cap at 200px (Figma). The list's own max-width is derived from the
+     column count so that:
+       - few columns  -> the row stays compact and centered (no lone 200px
+         column floating in the middle of a 1600px panel);
+       - many columns -> the row is capped by .page-width (1600px) and each
+         column shrinks evenly via minmax(0, ...) instead of wrapping. */
+  --mega-menu-cols-safe: max(var(--mega-menu-cols, 6), 1);
   display: grid;
-  gap: 1.125rem 3rem;
-  grid-template-columns: repeat(6, minmax(320px, 1fr));
+  grid-template-columns: repeat(var(--mega-menu-cols, 6), minmax(0, var(--mega-menu-col-width)));
+  justify-content: center;
+  gap: 2rem var(--mega-menu-col-gap);
+  max-width: calc(
+    var(--mega-menu-cols-safe) * var(--mega-menu-col-width) +
+    (var(--mega-menu-cols-safe) - 1) * var(--mega-menu-col-gap)
+  );
+  margin-inline: auto;
   list-style: none;
+  padding: 0;
+}
+
+
+.mega-menu__col {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem; /* 24px heading -> list / title -> image (Figma) */
+  min-width: 0;
+}
+
+/* Column heading (bold, non-link or link) */
+.mega-menu__heading {
+  display: block;
+  font-weight: 700;
+  font-size: 1rem; /* 16px */
+  line-height: 1.5; /* 24px */
+  color: rgb(var(--color-base-foreground));
+  text-decoration: none;
+}
+
+.mega-menu__heading--link {
+  transition: color var(--duration-short) ease;
+}
+
+.mega-menu__heading--link:hover {
+  color: var(--color-accent);
+}
+
+/* Link list under a heading */
+.mega-menu__sublist {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem; /* 16px between items (Figma) */
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .mega-menu__link {
-  color: rgba(var(--color-base-foreground), 0.75);
-  display: block;
-  line-height: calc(1 + 0.3 / var(--font-body-scale));
-  padding-bottom: 0.6rem;
-  padding-top: 0.6rem;
+  display: inline-block;
+  font-weight: 400;
+  font-size: 1rem; /* 16px */
+  line-height: 1.5; /* 24px */
+  color: rgb(var(--color-base-foreground));
   text-decoration: none;
-  transition: text-decoration var(--duration-short) ease;
+  transition: color var(--duration-short) ease;
   word-wrap: break-word;
-}
-
-.mega-menu__link--level-2 {
-  font-weight: bold;
-}
-
-.header--top-center .mega-menu__list {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  column-gap: 0;
-}
-
-.header--top-center .mega-menu__list > li {
-  width: 16%;
-  padding-right: 2.4rem;
 }
 
 .mega-menu__link:hover,
 .mega-menu__link--active {
-  /* color: rgb(var(--color-base-foreground)); */
+  color: var(--color-accent);
 }
 
-.mega-menu .mega-menu__list--condensed {
+/* Image-card variant */
+.mega-menu__card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem; /* 24px title -> image (Figma) */
+  text-decoration: none;
+  color: rgb(var(--color-base-foreground));
+}
+
+.mega-menu__card-title {
+  font-weight: 700;
+  font-size: 1rem; /* 16px */
+  line-height: 1.5; /* 24px */
+  /* Keep titles to a single line so every image in a row starts at the same
+     Y position (Figma: fixed 24px title height above each 200px image). */
+  min-height: 1.5em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color var(--duration-short) ease;
+}
+
+.mega-menu__card:hover .mega-menu__card-title {
+  color: var(--color-accent);
+}
+
+.mega-menu__card-img,
+.mega-menu__card-img--placeholder {
   display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  background-color: var(--color-gray-100, rgba(var(--color-base-foreground), 0.06));
 }
 
-.mega-menu__list--condensed .mega-menu__link {
-  font-weight: normal;
+/* Full-width "All <category>" CTA */
+.mega-menu__cta-all {
+  display: block;
+  margin-top: 2rem;
+  padding-top: 1rem; /* 16px above the CTA (Figma) */
+  border-top: 1px solid var(--color-gray-200, rgba(var(--color-base-foreground), 0.12));
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.25rem; /* 20px */
+  line-height: 1.5; /* 30px */
+  text-decoration: underline;
+  color: rgb(var(--color-base-foreground));
+  transition: color var(--duration-short) ease;
+}
+
+.mega-menu__cta-all:hover {
+  color: var(--color-accent);
 }

--- a/shopify.theme.toml
+++ b/shopify.theme.toml
@@ -1,6 +1,5 @@
 [environments.international]
 store = "sportfinder-international.myshopify.com"
-ignore = ["config/settings_data.json"]
 
 [environments.czech]
 store = "northfinder-cz.myshopify.com"

--- a/snippets/header-mega-menu.liquid
+++ b/snippets/header-mega-menu.liquid
@@ -1,6 +1,18 @@
 {% comment %}
   Renders a megamenu for the header.
 
+  Two layouts, auto-detected per top-level link:
+    - "image": direct children are leaf links (no grandchildren) and at least
+      one resolves an image (menu.image metafield / featured_image). Renders a
+      row of category cards (heading + square image). Matches the Figma
+      Obuv / Doplnky / Aktivity states.
+    - "text": otherwise. Renders columns of a bold heading + link list. Matches
+      the Figma Winter Sale / Muži / Ženy states.
+
+  A full-width "All <category>" CTA is rendered at the bottom of every panel,
+  reusing the mobile convention: the child link whose URL matches the parent
+  link's URL is the "All" link.
+
   Usage:
   {% render 'header-mega-menu' %}
 {% endcomment %}
@@ -26,6 +38,33 @@
     {%- for link in section.settings.menu.links -%}
       <li>
         {%- if link.links != blank -%}
+          {%- liquid
+            assign mega_layout = 'text'
+            assign has_grandchildren = false
+            assign has_image = false
+            for childlink in link.links
+              if childlink.links != blank
+                assign has_grandchildren = true
+              endif
+              if childlink.object.metafields.menu.image.value != blank or childlink.object.featured_image or childlink.object.image
+                assign has_image = true
+              endif
+            endfor
+            if has_grandchildren == false and has_image
+              assign mega_layout = 'image'
+            endif
+
+            assign all_link = link.links | where: 'url', link.url | first
+
+            # Column count = child links minus the "All" link (rendered as CTA, not a column).
+            assign mega_col_count = link.links.size
+            if all_link != blank
+              assign mega_col_count = mega_col_count | minus: 1
+            endif
+            if mega_col_count < 1
+              assign mega_col_count = 1
+            endif
+          -%}
           <header-menu>
             <details id="Details-HeaderMenu-{{ forloop.index }}" class="mega-menu h-full">
               <summary
@@ -44,79 +83,81 @@
                 class="mega-menu__content color-{{ section.settings.menu_color_scheme }} gradient global-settings-popup border-0 shadow-[0_20px_40px_#e2e2e2] overflow-hidden"
                 tabindex="-1"
               >
-                <ul
-                  class="mega-menu__list page-width"
-                  role="list"
-                >
-                  <li class="border-r border-[#E0DFDF]"></li>
-                  {% if link.levels == 1 %}
-                    <li>
-                      {%- if link.links != blank -%}
-                        <ul class="list-unstyled flex flex-col gap-y-3 items-start" role="list">
-                          {%- for childlink in link.links -%}
-                            <li>
-                              <a
-                                id="HeaderMenu-{{ link.handle }}-{{ link.handle }}-{{ childlink.handle }}"
-                                href="{{ childlink.url }}"
-                                class="mega-menu__link link no-underline {% if childlink.current %} mega-menu__link--active{% endif %} text-lg leading-[1.25rem] p-0 hover:text-accent transition-colors text-gray-950 tracking-normal"
-                                {% if childlink.current %}
-                                  aria-current="page"
-                                {% endif %}
-                              >
-                                {{ childlink.title | escape }}
-                              </a>
-                            </li>
-                          {%- endfor -%}
-                        </ul>
-                      {%- endif -%}
-                    </li>
-                  {% else %}
-                    {%- for childlink in link.links -%}
-                      <li class="flex flex-col gap-6 border-r border-[#E0DFDF] last:border-0">
-                        {%- if childlink.links == blank and childlink.url != blank -%}
+                <div class="mega-menu__inner page-width">
+                  {%- if mega_layout == 'image' -%}
+                    <ul class="mega-menu__list mega-menu__list--image" role="list" style="--mega-menu-cols: {{ mega_col_count }};">
+                      {%- for childlink in link.links -%}
+                        {%- if childlink.url == link.url -%}{%- continue -%}{%- endif -%}
+                        <li class="mega-menu__col">
                           <a
                             id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
                             href="{{ childlink.url }}"
-                            class="text-base font-bold leading-[1.3125rem] text-black hover:text-accent transition-colors"
-                            {% if childlink.current %}
-                              aria-current="page"
-                            {% endif %}
+                            class="mega-menu__card{% if childlink.current %} mega-menu__card--active{% endif %}"
+                            {% if childlink.current %}aria-current="page"{% endif %}
                           >
-                            {{ childlink.title | escape }}
+                            <span class="mega-menu__card-title">{{ childlink.title | escape }}</span>
+                            {% render 'menu-link-image',
+                              link: childlink,
+                              size: 400,
+                              image_class: 'mega-menu__card-img',
+                              widths: '200,400',
+                              sizes: '200px'
+                            %}
                           </a>
-                        {%- else -%}
-                          <span
-                            id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
-                            class="text-base font-bold leading-[1.3125rem] cursor-default text-black"
-                            {% if childlink.current %}
-                              aria-current="page"
-                            {% endif %}
-                          >
-                            {{ childlink.title | escape }}
-                          </span>
-                        {%- endif -%}
-                        {%- if childlink.links != blank -%}
-                          <ul class="list-unstyled flex flex-col gap-y-3 items-start" role="list">
-                            {%- for grandchildlink in childlink.links -%}
-                              <li>
-                                <a
-                                  id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
-                                  href="{{ grandchildlink.url }}"
-                                  class="mega-menu__link link no-underline{% if grandchildlink.current %} mega-menu__link--active{% endif %} text-lg leading-[1.25rem] p-0 hover:text-accent transition-colors text-gray-950 tracking-normal"
-                                  {% if grandchildlink.current %}
-                                    aria-current="page"
-                                  {% endif %}
-                                >
-                                  {{ grandchildlink.title | escape }}
-                                </a>
-                              </li>
-                            {%- endfor -%}
-                          </ul>
-                        {%- endif -%}
-                      </li>
-                    {%- endfor -%}
-                  {% endif %}
-                </ul>
+                        </li>
+                      {%- endfor -%}
+                    </ul>
+                  {%- else -%}
+                    <ul class="mega-menu__list mega-menu__list--text" role="list" style="--mega-menu-cols: {{ mega_col_count }};">
+                      {%- for childlink in link.links -%}
+                        {%- if childlink.url == link.url -%}{%- continue -%}{%- endif -%}
+                        <li class="mega-menu__col">
+                          {%- if childlink.links == blank and childlink.url != blank -%}
+                            <a
+                              id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                              href="{{ childlink.url }}"
+                              class="mega-menu__heading mega-menu__heading--link"
+                              {% if childlink.current %}aria-current="page"{% endif %}
+                            >
+                              {{ childlink.title | escape }}
+                            </a>
+                          {%- else -%}
+                            <span
+                              id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
+                              class="mega-menu__heading"
+                              {% if childlink.current %}aria-current="page"{% endif %}
+                            >
+                              {{ childlink.title | escape }}
+                            </span>
+                          {%- endif -%}
+                          {%- if childlink.links != blank -%}
+                            <ul class="mega-menu__sublist" role="list">
+                              {%- for grandchildlink in childlink.links -%}
+                                {%- if grandchildlink.url == childlink.url -%}{%- continue -%}{%- endif -%}
+                                <li>
+                                  <a
+                                    id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                                    href="{{ grandchildlink.url }}"
+                                    class="mega-menu__link{% if grandchildlink.current %} mega-menu__link--active{% endif %}"
+                                    {% if grandchildlink.current %}aria-current="page"{% endif %}
+                                  >
+                                    {{ grandchildlink.title | escape }}
+                                  </a>
+                                </li>
+                              {%- endfor -%}
+                            </ul>
+                          {%- endif -%}
+                        </li>
+                      {%- endfor -%}
+                    </ul>
+                  {%- endif -%}
+
+                  {%- if all_link != blank -%}
+                    <a href="{{ all_link.url }}" class="mega-menu__cta-all">{{ all_link.title | escape }}</a>
+                  {%- elsif link.url != blank -%}
+                    <a href="{{ link.url }}" class="mega-menu__cta-all">{{ 'mobile_menu.all_in' | t: title: link.title }}</a>
+                  {%- endif -%}
+                </div>
               </div>
             </details>
           </header-menu>

--- a/snippets/menu-link-image.liquid
+++ b/snippets/menu-link-image.liquid
@@ -1,5 +1,5 @@
 {% doc %}
-  Renders a 128px square photo tile image for a menu link.
+  Renders a square photo tile image for a menu link.
 
   Resolution order:
     1. link.object.metafields.menu.image (file_reference, optional override)
@@ -9,6 +9,9 @@
 
   @param {object} link - Liquid link object from a linklist
   @param {string} [size] - Image source width hint (defaults to 256)
+  @param {string} [image_class] - CSS class for the <img> / placeholder (defaults to menu-drawer__tile-img)
+  @param {string} [widths] - image_tag widths attribute (defaults to '128,256')
+  @param {string} [sizes] - image_tag sizes attribute (defaults to '128px')
 
   @example
     {% render 'menu-link-image', link: childlink %}
@@ -25,6 +28,13 @@
   endif
 
   assign target_width = size | default: 256
+  assign img_class = image_class | default: 'menu-drawer__tile-img'
+  assign placeholder_class = 'menu-drawer__tile-img--placeholder'
+  if image_class != blank
+    assign placeholder_class = image_class | append: '--placeholder'
+  endif
+  assign img_widths = widths | default: '128,256'
+  assign img_sizes = sizes | default: '128px'
 -%}
 
 {%- if img != blank -%}
@@ -32,12 +42,12 @@
     img
     | image_url: width: target_width
     | image_tag:
-      class: 'menu-drawer__tile-img',
+      class: img_class,
       loading: 'lazy',
-      widths: '128,256',
-      sizes: '128px',
+      widths: img_widths,
+      sizes: img_sizes,
       alt: link.title
   }}
 {%- else -%}
-  <span class="menu-drawer__tile-img--placeholder" aria-hidden="true"></span>
+  <span class="{{ placeholder_class }}" aria-hidden="true"></span>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- Implement full-width desktop mega menu panel with auto grid columns
- Image+text items with `nowrap + ellipsis` for consistent Y-axis alignment
- CTA link convention (child URL == parent URL) reused from mobile drawer
- Add optional `image_class`/`widths`/`sizes` params to `menu-link-image`
- Remove `international` ignore for `settings_data.json` in `shopify.theme.toml`

## Files changed
- `assets/component-mega-menu.css` — Figma-accurate mega menu styles
- `snippets/header-mega-menu.liquid` — image/text auto-detect + CTA
- `snippets/menu-link-image.liquid` — optional image sizing params
- `shopify.theme.toml` — remove ignore rule

## Verification
- Draft theme pushed to `sportfinder-international.myshopify.com`
- Preview: `https://shop.northfinder.com/?preview_theme_id=201445507404`
- Verified via agent-browser: MEN (3 cols, centered), WOMEN, HIKING SHOES (7 cols, 1 row), EQUIPMENT (6 cols), mobile drawer unaffected