### PR TITLE
Fix storefront customer login redirects

### DIFF
--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -323,7 +323,7 @@
           {% endif %}
           {% if section.settings.show_login and customer == null %}
           <div>
-            <a href="{{ routes.account_login_url }}">{{ 'customer.login_page.sign_in' | t }}</a>
+            <a href="{{ routes.storefront_login_url }}">{{ 'customer.login_page.sign_in' | t }}</a>
           </div>
           {% endif %}
           {% if customer != null %}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -182,7 +182,7 @@
 
       {%- if shop.customer_accounts_enabled -%}
         <a
-          href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.account_login_url }}{%- endif -%}"
+          href="{%- if customer -%}{{ routes.account_url }}{%- else -%}{{ routes.storefront_login_url }}{%- endif -%}"
           class="header__icon px-3 header__icon--account link focus-inset{% if section.settings.menu != blank %} small-hide{% endif %}"
           rel="nofollow"
           id="user-menu-trigger"

--- a/sections/main-cart-items-original.liquid
+++ b/sections/main-cart-items-original.liquid
@@ -43,7 +43,7 @@
       {%- if shop.customer_accounts_enabled and customer == null -%}
         <h2 class="cart__login-title">{{ 'sections.cart.login.title' | t }}</h2>
         <p class="cart__login-paragraph">
-          {{ 'sections.cart.login.paragraph_html' | t: link: routes.account_login_url }}
+          {{ 'sections.cart.login.paragraph_html' | t: link: routes.storefront_login_url }}
         </p>
       {%- endif -%}
     </div>

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -209,7 +209,7 @@
       {%- if shop.customer_accounts_enabled and customer == null -%}
         <h2 class="cart__login-title">{{ 'sections.cart.login.title' | t }}</h2>
         <p class="cart__login-paragraph">
-          {{ 'sections.cart.login.paragraph_html' | t: link: routes.account_login_url }}
+          {{ 'sections.cart.login.paragraph_html' | t: link: routes.storefront_login_url }}
         </p>
       {%- endif -%}
     </div>
@@ -523,7 +523,7 @@
             </button>
 
             {% if section.settings.show_login_button and shop.customer_accounts_enabled and customer == null %}
-              <a href="{{ routes.account_login_url }}" class="nf-cart-login__button">
+              <a href="{{ routes.storefront_login_url }}" class="nf-cart-login__button">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                   <path d="M8 8C10.2091 8 12 6.20914 12 4C12 1.79086 10.2091 0 8 0C5.79086 0 4 1.79086 4 4C4 6.20914 5.79086 8 8 8Z" fill="currentColor"/>
                   <path d="M8 9C5.33333 9 0 10.3333 0 13V16H16V13C16 10.3333 10.6667 9 8 9Z" fill="currentColor"/>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -49,7 +49,7 @@
               {%- if shop.customer_accounts_enabled and customer == null -%}
                 <p class="cart__login-title h3">{{ 'sections.cart.login.title' | t }}</p>
                 <p class="cart__login-paragraph">
-                  {{ 'sections.cart.login.paragraph_html' | t: link: routes.account_login_url }}
+                  {{ 'sections.cart.login.paragraph_html' | t: link: routes.storefront_login_url }}
                 </p>
               {%- endif -%}
             </div>

--- a/snippets/header-drawer.liquid
+++ b/snippets/header-drawer.liquid
@@ -147,7 +147,7 @@
                 </a>
               {% else %}
                 <a
-                  href="{{ routes.account_login_url }}"
+                  href="{{ routes.storefront_login_url }}"
                   class="w-full button h-[var(--control-height-md)] leading-7 flex items-center justify-center"
                 >
                   {{ 'customer.login_page.sign_in' | t | default: 'Login' }}

--- a/snippets/user-menu-popup.liquid
+++ b/snippets/user-menu-popup.liquid
@@ -89,7 +89,7 @@
         <p class="user-menu-popup__login-text">
           {{ 'customer.login.please_login' | t }}
         </p>
-        <a href="{{ routes.account_login_url }}" class="user-menu-popup__login-button">
+        <a href="{{ routes.storefront_login_url }}" class="user-menu-popup__login-button">
           {{ 'customer.login.sign_in' | t }}
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Use Shopify's storefront login route for guest account links so successful sign-in returns customers to the originating storefront page
- Keep logged-in account links pointed at the customer account route

## Verification
- git diff --check
- shopify theme check --path . --output json, filtered to changed files: no offenses