### PR TITLE
feat(localization): unify cross-market language selector

### DIFF
--- a/assets/localization-form.js
+++ b/assets/localization-form.js
@@ -7,7 +7,7 @@ if (!customElements.get('localization-form')) {
         this.mql = window.matchMedia('(min-width: 750px)');
         this.header = document.querySelector('.header-wrapper');
         this.elements = {
-          input: this.querySelector('input[name="locale_code"], input[name="country_code"]'),
+          input: this.querySelector('input[name="language_code"], input[name="country_code"]'),
           button: this.querySelector('button.localization-form__select'),
           panel: this.querySelector('.disclosure__list-wrapper'),
           search: this.querySelector('input[name="country_filter"]'),
@@ -108,6 +108,11 @@ if (!customElements.get('localization-form')) {
       onItemClick(event) {
         if (event.currentTarget.dataset.externalMarket === 'true') {
           this.hidePanel();
+          const marketUrl = event.currentTarget.dataset.marketUrl;
+          if (marketUrl) {
+            event.preventDefault();
+            window.location.assign(marketUrl);
+          }
           return;
         }
         event.preventDefault();

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -4,7 +4,7 @@
   if settings.show_country_selector and localization.available_countries.size > 1
     assign show_ab_country = true
   endif
-  if settings.show_language_selector and localization.available_languages.size > 1
+  if settings.show_language_selector
     assign show_ab_language = true
   endif
 -%}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -337,7 +337,7 @@
                 assign show_country = true
               endif
               assign show_language = false
-              if section.settings.enable_language_selector and localization.available_languages.size > 1
+              if section.settings.enable_language_selector
                 assign show_language = true
               endif
             -%}
@@ -359,7 +359,7 @@
                     {%- endform -%}
                   </localization-form>
                 {%- endif -%}
-                {%- if section.settings.enable_language_selector and localization.available_languages.size > 1 -%}
+                {%- if section.settings.enable_language_selector -%}
                   <localization-form>
                     {%- form 'localization', id: 'FooterLanguageForm', class: 'localization-form' -%}
                       <div>

--- a/snippets/header-drawer.liquid
+++ b/snippets/header-drawer.liquid
@@ -161,7 +161,7 @@
               if settings.show_country_selector and localization.available_countries.size > 1
                 assign show_drawer_country = true
               endif
-              if settings.show_language_selector and localization.available_languages.size > 1
+              if settings.show_language_selector
                 assign show_drawer_language = true
               endif
             -%}

--- a/snippets/language-localization-option.liquid
+++ b/snippets/language-localization-option.liquid
@@ -1,0 +1,45 @@
+{% doc %}
+  Renders one language option for the global language selector.
+
+  @param {string} iso_code - The language ISO code
+  @param {string} label - The language endonym
+  @param {string} fallback_url - The canonical market URL when the language is unavailable here
+  @param {shop_locale[]} available_languages - Languages available in the current market
+{% enddoc %}
+
+{%- liquid
+  assign native_language = available_languages | where: 'iso_code', iso_code | first
+  assign is_current = false
+  assign is_native = false
+  if iso_code == localization.language.iso_code
+    assign is_current = true
+  endif
+  if native_language != blank
+    assign is_native = true
+  endif
+-%}
+
+<li class="disclosure__item{% unless is_native %} disclosure__item--external{% endunless %}" tabindex="-1">
+  <a
+    class="link link--text disclosure__link caption-large focus-inset"
+    {% if is_native %}
+      href="#"
+      data-value="{{ iso_code }}"
+    {% else %}
+      href="{{ fallback_url }}"
+      rel="alternate"
+      data-external-market="true"
+      data-market-url="{{ fallback_url }}"
+    {% endif %}
+    hreflang="{{ iso_code }}"
+    lang="{{ iso_code }}"
+    {% if is_current %}
+      aria-current="true"
+    {% endif %}
+  >
+    <span{% unless is_current %} class="visibility-hidden"{% endunless %}>
+      {{- 'icon-checkmark.svg' | inline_asset_content -}}
+    </span>
+    <span>{{ label }}</span>
+  </a>
+</li>

--- a/snippets/language-localization.liquid
+++ b/snippets/language-localization.liquid
@@ -1,52 +1,14 @@
 {%- comment -%}
-  Renders the language picker for the localization form.
+  Renders one global language list for every Northfinder market.
 
-  Supports up to 4 cross-market slots (settings.cross_market_*, cross_market_2_*, …).
-  Each slot defines an external market on a separate domain. Behavior:
-    - When request.host matches a slot's host_match, the picker is rendered in
-      "external" mode for that slot: in-store language switches redirect to the
-      slot's home_url instead of changing locale on the external host.
-    - When on the home shop, every slot whose external URL + label are set
-      appends an extra <li> linking to that external market.
+  A language uses Shopify's native localization form when it is published in
+  the current market. Otherwise, it links to the canonical market URL from
+  the shared registry below.
 
   Accepts:
     - localPosition: pass in the position in which the form is coming up to
       create specific IDs.
 {%- endcomment -%}
-
-{%- liquid
-  assign on_external_market = false
-  assign active_override_url = ''
-  assign active_override_default_iso = ''
-
-  for slot_index in (1..4)
-    case slot_index
-      when 1
-        assign slot_host = settings.cross_market_host_match
-        assign slot_home_url = settings.cross_market_home_url
-        assign slot_home_default_iso = settings.cross_market_home_default_iso
-      when 2
-        assign slot_host = settings.cross_market_2_host_match
-        assign slot_home_url = settings.cross_market_2_home_url
-        assign slot_home_default_iso = settings.cross_market_2_home_default_iso
-      when 3
-        assign slot_host = settings.cross_market_3_host_match
-        assign slot_home_url = settings.cross_market_3_home_url
-        assign slot_home_default_iso = settings.cross_market_3_home_default_iso
-      when 4
-        assign slot_host = settings.cross_market_4_host_match
-        assign slot_home_url = settings.cross_market_4_home_url
-        assign slot_home_default_iso = settings.cross_market_4_home_default_iso
-    endcase
-
-    assign slot_host = slot_host | strip
-    if slot_host != blank and request.host contains slot_host
-      assign on_external_market = true
-      assign active_override_url = slot_home_url | strip
-      assign active_override_default_iso = slot_home_default_iso | strip | downcase
-    endif
-  endfor
--%}
 
 <div class="disclosure">
   <button
@@ -61,107 +23,67 @@
   </button>
   <div class="disclosure__list-wrapper language-selector" hidden>
     <ul id="{{ localPosition }}List" role="list" class="disclosure__list list-unstyled">
-      {%- for language in localization.available_languages -%}
-        {%- liquid
-          assign is_override = false
-          if on_external_market and active_override_url != blank and language.iso_code != localization.language.iso_code
-            assign is_override = true
-          endif
-          assign override_target = active_override_url
-          if is_override
-            assign override_base = active_override_url | split: '?' | first | split: '#' | first
-            assign last_char = override_base | slice: -1
-            assign lang_iso_lower = language.iso_code | downcase
-            if active_override_default_iso != blank and lang_iso_lower == active_override_default_iso
-              if last_char == '/'
-                assign override_target = override_base
-              else
-                assign override_target = override_base | append: '/'
-              endif
-            else
-              if last_char == '/'
-                assign override_target = override_base | append: language.iso_code | append: '/'
-              else
-                assign override_target = override_base | append: '/' | append: language.iso_code | append: '/'
-              endif
-            endif
-          endif
-        -%}
-        <li class="disclosure__item{% if is_override %} disclosure__item--external{% endif %}" tabindex="-1">
-          <a
-            class="link link--text disclosure__link caption-large focus-inset"
-            {% if is_override -%}
-              href="{{ override_target }}"
-              rel="alternate"
-              data-external-market="true"
-            {%- else -%}
-              href="#"
-              data-value="{{ language.iso_code }}"
-            {%- endif %}
-            hreflang="{{ language.iso_code }}"
-            lang="{{ language.iso_code }}"
-            {% if language.iso_code == localization.language.iso_code %}
-              aria-current="true"
-            {% endif %}
-          >
-            <span
-              {% if language.iso_code != localization.language.iso_code %}
-                class="visibility-hidden"
-              {% endif %}
-            >
-              {{- 'icon-checkmark.svg' | inline_asset_content -}}
-            </span>
-            <span>{{ language.endonym_name | capitalize }}</span>
-          </a>
-        </li>
-      {%- endfor -%}
-      {%- if on_external_market == false -%}
-        {%- for slot_index in (1..4) -%}
-          {%- liquid
-            case slot_index
-              when 1
-                assign append_url = settings.cross_market_language_url
-                assign append_label = settings.cross_market_language_label
-                assign append_iso = settings.cross_market_language_iso
-              when 2
-                assign append_url = settings.cross_market_2_language_url
-                assign append_label = settings.cross_market_2_language_label
-                assign append_iso = settings.cross_market_2_language_iso
-              when 3
-                assign append_url = settings.cross_market_3_language_url
-                assign append_label = settings.cross_market_3_language_label
-                assign append_iso = settings.cross_market_3_language_iso
-              when 4
-                assign append_url = settings.cross_market_4_language_url
-                assign append_label = settings.cross_market_4_language_label
-                assign append_iso = settings.cross_market_4_language_iso
-            endcase
-            assign append_url = append_url | strip
-            assign append_label = append_label | strip
-            assign append_iso = append_iso | strip
-          -%}
-          {%- if append_url != blank and append_label != blank -%}
-            <li class="disclosure__item disclosure__item--external" tabindex="-1">
-              <a
-                class="link link--text disclosure__link caption-large focus-inset"
-                href="{{ append_url }}"
-                {% if append_iso != blank %}
-                  hreflang="{{ append_iso }}"
-                  lang="{{ append_iso }}"
-                {% endif %}
-                rel="alternate"
-                data-external-market="true"
-              >
-                <span class="visibility-hidden">
-                  {{- 'icon-checkmark.svg' | inline_asset_content -}}
-                </span>
-                <span>{{ append_label | capitalize }}</span>
-              </a>
-            </li>
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endif -%}
+      {%- render 'language-localization-option',
+        iso_code: 'en',
+        label: 'English',
+        fallback_url: 'https://shop.northfinder.com/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'hr',
+        label: 'Hrvatski',
+        fallback_url: 'https://shop.northfinder.com/hr/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'sl',
+        label: 'Slovenščina',
+        fallback_url: 'https://shop.northfinder.com/sl/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'de',
+        label: 'Deutsch',
+        fallback_url: 'https://shop.northfinder.com/de/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'bg',
+        label: 'Български',
+        fallback_url: 'https://northfinder.bg/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'sk',
+        label: 'Slovenčina',
+        fallback_url: 'https://northfinder.sk/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'cs',
+        label: 'Čeština',
+        fallback_url: 'https://northfinder.com/cs/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'ro',
+        label: 'Română',
+        fallback_url: 'https://northfinder.com/ro/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'hu',
+        label: 'Magyar',
+        fallback_url: 'https://northfinder.com/hu/',
+        available_languages: localization.available_languages
+      -%}
+      {%- render 'language-localization-option',
+        iso_code: 'pl',
+        label: 'Polski',
+        fallback_url: 'https://northfinder.com/pl/',
+        available_languages: localization.available_languages
+      -%}
     </ul>
   </div>
 </div>
-<input type="hidden" name="locale_code" value="{{ localization.language.iso_code }}">
+<input type="hidden" name="language_code" value="{{ localization.language.iso_code }}">


### PR DESCRIPTION
## What changed

- Render one consistent 10-language registry across all Shopify markets.
- Keep native Shopify localization when a language is published in the current market.
- Redirect unpublished languages to their canonical Shopify or legacy Northfinder market URL.
- Keep the selector visible in announcement bar, footer, and mobile header drawer regardless of the current market language count.
- Handle external market links explicitly in the localization form JavaScript.

## Why

Markets publish different language subsets, so the old selector could disappear or expose different options. This keeps the visual and navigation model consistent while preserving native Shopify locale switching where available.

## Validation

- `pnpm test:ci` — 21 tests passed.
- `git diff --check` — passed.
- Draft theme `201906454860` verified with Browser plugin: 10 language options on desktop and the same 10 options in the mobile drawer at 390px.
- Legacy fallbacks for `cs`, `ro`, `hu`, and `pl` point to northfinder.com locale paths.

The unrelated pre-existing `ecom-*` missing-section warnings from Shopify theme push are outside this change.