### PR TITLE
Fix color thumbnail fallbacks and draft theme rendering

### DIFF
--- a/assets/product-utils.module.js
+++ b/assets/product-utils.module.js
@@ -1,6 +1,6 @@
 // Pre-compiled patterns for better performance
 const TYPE_CODES = ['H', 'D', 'M', 'B', 'BV', 'X'];
-const TYPE_CODE_PATTERN = /^(H|D|M|B|BV|X)(_\d+)?$/;
+const TYPE_CODE_PATTERN = /^(H|D|M|B|BV|X)(?:_\d+)*$/;
 const URL_SPLIT_QUERY = /\?v=/;
 const PATH_SPLIT_SLASH = /\//;
 const EXTENSION_PATTERN = /\.[^/.]+$/;

--- a/assets/product-utils.test.js
+++ b/assets/product-utils.test.js
@@ -1,6 +1,6 @@
 
 import { describe, test, expect } from "vitest";
-import { parseImageUrl, sortImagesByDisplayRules } from "./product-utils.module.js";
+import { filterMediaByColor, parseImageUrl, sortImagesByDisplayRules } from "./product-utils.module.js";
 
 describe("parseImageUrl", () => {
   // New format tests (NF-no-)
@@ -245,6 +245,37 @@ describe("parseImageUrl", () => {
       reference_id: 696,
       unique_id: expect.any(String),
     });
+  });
+
+  test("parses a normalized duplicate suffix after a model sequence", () => {
+    const result = parseImageUrl(
+      "no-4894snw-women-s-ski-comfortable-trousers-with-braces-alma-NF-NO-4894SNW-526-M_1_2.jpg",
+    );
+    expect(result).toEqual({
+      product: "NF-NO-4894SNW",
+      color: "color-526",
+      image_type: "model",
+      sequence: 1,
+      reference_id: 526,
+      unique_id: expect.any(String),
+    });
+  });
+});
+
+describe("filterMediaByColor", () => {
+  test("keeps ALMA model images with normalized duplicate suffixes in the selected color", () => {
+    const mediaUrls = [
+      "no-4894snw-women-s-ski-comfortable-trousers-with-braces-alma-NF-NO-4894SNW-526-H.jpg",
+      "no-4894snw-women-s-ski-comfortable-trousers-with-braces-alma-NF-NO-4894SNW-526-M_1_2.jpg",
+      "no-4894snw-women-s-ski-comfortable-trousers-with-braces-alma-NF-NO-4894SNW-526-M_2_2.jpg",
+      "no-4894snw-women-s-ski-comfortable-trousers-with-braces-alma-NF-NO-4894SNW-269-H.jpg",
+    ];
+    const colorMappings = [
+      { name: "black", reference_id: 269 },
+      { name: "inkblue", reference_id: 526 },
+    ];
+
+    expect(filterMediaByColor(mediaUrls, "526", colorMappings)).toEqual(mediaUrls.slice(0, 3));
   });
 });
 

--- a/docs/color-thumbnail-logic.md
+++ b/docs/color-thumbnail-logic.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document explains the complex logic used to retrieve color-specific product images (thumbnails) based on color variants in the Shopify theme. The system prioritizes model images with specific naming conventions and fallback strategies.
+This document explains how the theme retrieves color-specific product thumbnails from variant data, SKU references, and product media.
 
 ## Image Naming Convention
 
@@ -59,6 +59,7 @@ A simplified wrapper around the core utility:
 {% render 'get-variant-color-image',
   product: product,
   color_value: color_value,
+  variant: variant,
   width: 80,
   height: 80,
   crop: 'center',
@@ -66,63 +67,29 @@ A simplified wrapper around the core utility:
 %}
 ```
 
-## Priority Logic for Model Images (image_type: 'M')
+## Canonical Priority Logic
 
-When `image_type: 'M'` is specified, the system follows this priority order:
+All PDP and product-card color thumbnails use this order:
 
-### Step 1: Find Reference ID
-```liquid
-{% assign color_value_normalized = color_value | downcase | strip | replace: ' ', '-' %}
-{% if product.metafields.custom.color.value != blank %}
-  {% for color_item in product.metafields.custom.color.value %}
-    {% if color_item.name == color_value_normalized %}
-      {% assign reference_id = color_item.reference_id %}
-      {% break %}
-    {% endif %}
-  {% endfor %}
-{% endif %}
-```
+1. `variant.featured_image`
+2. Same-reference `-H`
+3. Same-reference `-M`
+4. Same-reference lowest numbered `-M_1`, `-M_2`, `-M_3`...
+5. Same-reference lowest numbered `-D_1`, `-D_2`, `-D_3`...
+6. Same-reference `-BV`
+7. Same-reference `-B`
+8. Native color swatch
+9. Placeholder
 
-### Step 2: Priority Order
-1. **Highest Priority**: Model image without sequence (`-M`)
-   - Example: `NF-TR-4919OR-362-M.jpg`
+The resolver never falls back to another color's model image or product featured image.
 
-2. **Second Priority**: Model image with lowest sequence number (`-M_1`, `-M_2`, `-M_3`...)
-   - Example: `NF-TR-4919OR-362-M_1.jpg` (preferred over `M_2`, `M_3`, etc.)
+The preferred reference source is the numeric segment before the size segment in the variant SKU. For example, `108139-490-372` resolves to reference `490`. The color metaobject `reference_id` is used when the SKU is unavailable or does not contain a valid numeric reference.
 
-### Step 3: Improved Sequence Selection Logic
+Media matching uses the exact `-<reference>-` token, and supports Shopify UUID suffixes such as `-M_1_<uuid>.jpg`.
 
-**Previous Issue**: Logic was selecting the first image found, not necessarily the lowest sequence.
+## Missing Image Behavior
 
-**Current Solution**:
-```liquid
-{% assign lowest_sequence = 999 %}
-{% assign best_model_media = nil %}
-
-{% for media in product.media %}
-  {% if parsed_url contains reference_id and parsed_url contains '-M_' %}
-    {% assign sequence_number = sequence_part | plus: 0 %}
-
-    {% if sequence_number > 0 and sequence_number < lowest_sequence %}
-      {% assign lowest_sequence = sequence_number %}
-      {% assign best_model_media = media %}
-    {% endif %}
-  {% endif %}
-{% endfor %}
-
-{% if best_model_media %}
-  {% assign image_url = best_model_media.preview_image | image_url: width: width, height: height, crop: crop %}
-{% endif %}
-```
-
-## Fallback Strategy
-
-If no model image is found, the system uses this fallback order:
-
-1. **Step 4**: Try to match by color name in URL
-2. **Step 5**: Try to find any image with color reference pattern
-3. **Step 6**: Fallback to first model image of any color
-4. **Step 7**: Final fallback to any product image
+When a color has no direct variant image and no same-reference media, `always` keeps the color visible and renders its native swatch or a placeholder. `thumbnail_only` hides that color. Neither mode may display an image belonging to another color.
 
 ## Files Using Color Thumbnails
 
@@ -133,6 +100,7 @@ If no model image is found, the system uses this fallback order:
 {% capture thumbnail_url %}{% render 'get-variant-color-image',
   product: product,
   color_value: color_value,
+  variant: value.variant,
   width: 80,
   height: 80,
   crop: 'center',
@@ -204,18 +172,19 @@ Given this media list for a product:
 
 ## Key Improvements Made
 
-1. **Fixed Sequence Priority**: Now correctly selects lowest sequence number
-2. **Added Validation**: `sequence_number > 0` to avoid invalid sequences
-3. **Consistent Implementation**: All files now use `image_type: 'M'` parameter
-4. **Better Performance**: Store best candidate and assign URL only once
+1. **Canonical priority**: H, M, M_n, D_n, BV, B after the direct variant image
+2. **SKU reference fallback**: Supports colors whose metafields are incomplete
+3. **Exact reference matching**: Prevents cross-color image leakage
+4. **Native swatch fallback**: Preserves the color when no image exists
+5. **Deterministic sequence selection**: Chooses the lowest numeric M/D sequence
 
 ## Best Practices
 
-1. **Always specify `image_type: 'M'`** for color thumbnails
-2. **Use consistent dimensions** across similar use cases
-3. **Include fallback logic** for when no color-specific image exists
-4. **Normalize color values** before processing
-5. **Strip whitespace** from captured URLs
+1. **Pass the exact variant** when one is available
+2. **Use the SKU reference** before the color metaobject reference
+3. **Match the complete `-<reference>-` token**
+4. **Keep `always` separate from image selection strictness**
+5. **Use native swatches before placeholders**
 
 ## Troubleshooting
 

--- a/sections/cart-notification-product.liquid
+++ b/sections/cart-notification-product.liquid
@@ -1,7 +1,6 @@
 {%- if cart != empty -%}
   {%- for item in cart.items -%}
     <div id="cart-notification-product-{{ item.key }}" class="cart-notification__item">
-      {%- if item.image -%}
         {% comment %} Extract color value from item options {% endcomment %}
         {% assign color_value = '' %}
         {% for option in item.options_with_values %}
@@ -20,6 +19,7 @@
           {% capture variant_image_url %}{% render 'get-variant-color-image',
             product: item.product,
             color_value: color_value_normalized,
+            variant: item.variant,
             width: 140,
             height: 140,
             crop: 'center',
@@ -52,7 +52,6 @@
             </div>
           {%- endif -%}
         </div>
-      {%- endif -%}
       <div class="cart-notification__item-details">
         <h3 class="cart-notification__item-title">{{ item.product.title | escape }}</h3>
         <div class="cart-notification__item-info">

--- a/sections/info-box.liquid
+++ b/sections/info-box.liquid
@@ -6,20 +6,17 @@
     {
       "type": "text",
       "id": "title",
-      "label": "Title",
-      "default": ""
+      "label": "Title"
     },
     {
       "type": "text",
       "id": "subtitle",
-      "label": "Subtitle",
-      "default": ""
+      "label": "Subtitle"
     },
     {
       "type": "text",
       "id": "button_text",
-      "label": "Button Text",
-      "default": ""
+      "label": "Button Text"
     },
     {
       "type": "url",

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -264,6 +264,7 @@
                                 {% capture variant_image_url %}{% render 'get-variant-color-image',
                                   product: item.product,
                                   color_value: color_value,
+                                  variant: item.variant,
                                   width: 300,
                                   height: 300,
                                   crop: 'center',

--- a/snippets/account-tab-orders.liquid
+++ b/snippets/account-tab-orders.liquid
@@ -125,6 +125,7 @@
                           {% capture variant_image_url %}{% render 'get-variant-color-image',
                             product: line_item.product,
                             color_value: color_value,
+                            variant: line_item.variant,
                             width: 100,
                             height: 100,
                             crop: 'center',
@@ -144,14 +145,6 @@
                         {% elsif line_item.image %}
                           <img
                             src="{{ line_item.image | image_url: width: 100, height: 100, crop: 'center' }}"
-                            alt="{{ line_item.title | escape }}"
-                            width="100"
-                            height="100"
-                            loading="lazy"
-                          >
-                        {% elsif line_item.product.featured_image %}
-                          <img
-                            src="{{ line_item.product.featured_image | image_url: width: 100, height: 100, crop: 'center' }}"
                             alt="{{ line_item.title | escape }}"
                             width="100"
                             height="100"

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -383,33 +383,46 @@
 
             {%- if color_variant -%}
               {%- liquid
-                # ============================================================
-                # PRIORITY ORDER (matches get-variant-color-image snippet):
-                # 1. variant.featured_image / variant.image (direct Shopify association)
-                # 2. reference_id from metafields + image naming patterns (-M, -M_N)
-                # 3. Color name matching in URL or alt text
-                # 4. featured_media fallback
-                # ============================================================
                 assign variant_image = null
                 assign variant_image_is_color_match = false
+                assign card_swatch = null
                 assign color_value = color | downcase | strip | replace: ' ', '-' | replace: "'", '' | replace: '.', '' | replace: ',', ''
 
-                # PRIORITY 1: Check variant.featured_image first (matching main product page logic)
                 if color_variant.featured_image
                   assign variant_image = color_variant.featured_image
                   assign variant_image_is_color_match = true
-                elsif color_variant.image
-                  assign variant_image = color_variant.image
-                  assign variant_image_is_color_match = true
                 endif
 
-                # PRIORITY 2: Use reference_id from metafields + image naming patterns
+                for product_option in card_product.options_with_values
+                  if product_option.position == color_option_position
+                    for option_value in product_option.values
+                      if option_value == color
+                        assign card_swatch = option_value.swatch
+                        break
+                      endif
+                    endfor
+                    break
+                  endif
+                endfor
+
                 unless variant_image
                   assign reference_id = ''
+                  if color_variant.sku != blank
+                    assign sku_parts = color_variant.sku | split: '-'
+                    assign reference_index = sku_parts.size | minus: 2
+                    if reference_index >= 0
+                      assign sku_reference_id = sku_parts[reference_index] | strip
+                      assign sku_reference_number = sku_reference_id | plus: 0
+                      if sku_reference_number > 0
+                        assign reference_id = sku_reference_id
+                      endif
+                    endif
+                  endif
 
-                  if card_product.metafields.custom.color.value != blank
+                  if reference_id == '' and card_product.metafields.custom.color.value != blank
                     for color_item in card_product.metafields.custom.color.value
-                      if color_item.name == color_value
+                      assign handle_root = color_item.system.handle | split: '-' | first | downcase
+                      if color_item.name == color_value or handle_root == color_value
                         assign reference_id = color_item.reference_id
                         break
                       endif
@@ -417,87 +430,59 @@
                   endif
 
                   if reference_id != '' and card_product.media.size > 0
-                    assign found_variant_image = false
-                    assign best_variant_seq = 999
+                    assign reference_token = '-' | append: reference_id | append: '-'
+                    assign hero_media = null
+                    assign model_media = null
+                    assign model_sequence_media = null
+                    assign detail_media = null
+                    assign back_variant_media = null
+                    assign back_media = null
+                    assign lowest_model_sequence = 999
+                    assign lowest_detail_sequence = 999
 
                     for media in card_product.media
                       assign media_src = media.src | default: ''
-                      assign parsed_url = media_src | split: '/' | last
-
-                      if parsed_url contains reference_id
-                        # Priority 2a: -M without sequence
-                        if parsed_url contains '-M'
-                          unless parsed_url contains '-M_'
-                            assign variant_image = media
-                            assign variant_image_is_color_match = true
-                            assign found_variant_image = true
-                            break
-                          endunless
+                      assign filename = media_src | split: '/' | last | split: '?' | first
+                      if filename contains reference_token
+                        assign type_token = filename | split: reference_token | last | split: '.' | first
+                        assign type_parts = type_token | split: '_'
+                        assign type_name = type_parts.first
+                        assign type_sequence = 0
+                        if type_parts.size > 1
+                          assign type_sequence = type_parts[1] | plus: 0
                         endif
 
-                        # Priority 2b: -M_N with lowest sequence
-                        if parsed_url contains '-M_' and found_variant_image == false
-                          assign seq_part = parsed_url | split: '-M_' | last | split: '.' | first
-                          assign seq_num = seq_part | plus: 0
-                          if seq_num > 0 and seq_num < best_variant_seq
-                            assign best_variant_seq = seq_num
-                            assign variant_image = media
-                            assign variant_image_is_color_match = true
+                        if type_name == 'H' and hero_media == null
+                          assign hero_media = media
+                        elsif type_name == 'M'
+                          if type_sequence > 0
+                            if type_sequence < lowest_model_sequence
+                              assign lowest_model_sequence = type_sequence
+                              assign model_sequence_media = media
+                            endif
+                          elsif model_media == null
+                            assign model_media = media
                           endif
-                        endif
-
-                        # Priority 2c: Other image types (H, B, BV, D)
-                        if variant_image == null
-                          if parsed_url contains '-H' or parsed_url contains '-B' or parsed_url contains '-BV' or parsed_url contains '-D'
-                            assign variant_image = media
-                            assign variant_image_is_color_match = true
+                        elsif type_name == 'D' and type_sequence > 0
+                          if type_sequence < lowest_detail_sequence
+                            assign lowest_detail_sequence = type_sequence
+                            assign detail_media = media
                           endif
+                        elsif type_name == 'BV' and back_variant_media == null
+                          assign back_variant_media = media
+                        elsif type_name == 'B' and back_media == null
+                          assign back_media = media
                         endif
                       endif
                     endfor
-                  endif
-                endunless
 
-                # PRIORITY 3: Try to find by color name in URL or alt text
-                unless variant_image
-                  if card_product.media.size > 0
-                    for media in card_product.media
-                      assign media_src = media.src | default: ''
-                      assign parsed_url = media_src | split: '/' | last
-
-                      if parsed_url contains color_value
-                        assign variant_image = media
-                        assign variant_image_is_color_match = true
-                        break
-                      endif
-
-                      if media.alt contains color or media.alt contains color_variant.title
-                        assign variant_image = media
-                        assign variant_image_is_color_match = true
-                        break
-                      endif
-                    endfor
-                  endif
-                endunless
-
-                # PRIORITY 4: Try product.images as last resort
-                unless variant_image
-                  for image in card_product.images
-                    if image.alt contains color or image.alt contains color_variant.title
-                      assign variant_image = image
+                    assign variant_image = hero_media | default: model_media | default: model_sequence_media | default: detail_media | default: back_variant_media | default: back_media
+                    if variant_image
                       assign variant_image_is_color_match = true
-                      break
                     endif
-                  endfor
+                  endif
                 endunless
 
-                # PRIORITY 5: Final fallback to featured_media (NOT a color-specific match)
-                unless variant_image
-                  assign variant_image = card_product.featured_media
-                endunless
-
-                # Strict mode: when merchant chose "Only with thumbnail", skip colors
-                # whose image could not be resolved by a color-specific match (P1-P4).
                 assign skip_card_color_value = false
                 if card_strict_thumbnail and variant_image_is_color_match == false
                   assign skip_card_color_value = true
@@ -536,13 +521,30 @@
                     class="w-full h-full object-cover"
                   >
                 {%- else -%}
-                  {%- comment -%} Show placeholder when no variant image is available {%- endcomment -%}
-                  <div class="variant-swatch-placeholder w-full h-full bg-gray-100 flex items-center justify-center">
-                    {{
-                      'product-apparel-2'
-                      | placeholder_svg_tag: 'variant-swatch-placeholder-svg w-3/5 h-3/5 text-gray-400 opacity-70'
-                    }}
-                  </div>
+                  {%- if card_swatch.image -%}
+                    <img
+                      src="{{ card_swatch.image | image_url: width: 120 }}"
+                      alt="{{ color | escape }}"
+                      loading="lazy"
+                      decoding="async"
+                      width="120"
+                      height="120"
+                      class="w-full h-full object-cover"
+                    >
+                  {%- elsif card_swatch.color -%}
+                    <span
+                      class="w-full h-full"
+                      style="background-color: rgb({{ card_swatch.color.rgb }});"
+                      aria-hidden="true"
+                    ></span>
+                  {%- else -%}
+                    <div class="variant-swatch-placeholder w-full h-full bg-gray-100 flex items-center justify-center">
+                      {{
+                        'product-apparel-2'
+                        | placeholder_svg_tag: 'variant-swatch-placeholder-svg w-3/5 h-3/5 text-gray-400 opacity-70'
+                      }}
+                    </div>
+                  {%- endif -%}
                 {%- endif -%}
               </a>
             {%- endif -%}

--- a/snippets/get-variant-color-image.liquid
+++ b/snippets/get-variant-color-image.liquid
@@ -33,95 +33,65 @@
 {% assign crop = crop | default: 'center' %}
 {% assign image_type = image_type | default: '' %}
 
-{% comment %}
-  IMPROVED LOGIC: Priority order for variant color thumbnails
-  1. PRIMARY: Get variant image directly from variant.featured_image or variant.image
-  2. FALLBACK: Use existing product-color-utils logic
-{% endcomment %}
-
 {% assign image_url = '' %}
 {% assign color_value_normalized = color_value | downcase | strip | replace: ' ', '-' | replace: "'", '' | replace: '.', '' | replace: ',', '' %}
+{% assign target_variant = variant | default: nil %}
 
-{% comment %} Step 1: Try to find variant with matching color and get its direct image {% endcomment %}
-{% if product.variants and color_value_normalized != blank %}
-  {% comment %} Find the color option position using centralized snippet {% endcomment %}
+{% if target_variant == blank and product.variants and color_value_normalized != blank %}
   {% capture color_option_position_raw %}
     {% render 'get-color-option-position', product: product %}
   {% endcapture %}
   {% assign color_option_position = color_option_position_raw | strip | plus: 0 %}
 
-  {% comment %} Find variant that matches the color value {% endcomment %}
   {% if color_option_position > 0 %}
-    {% comment %} First pass: Look for available variants with matching color {% endcomment %}
-    {% for variant in product.variants %}
-      {% if variant.available %}
-        {% comment %} Get the color option value for this variant {% endcomment %}
+    {% for variant_candidate in product.variants %}
+      {% if variant_candidate.available %}
         {% case color_option_position %}
           {% when 1 %}
-            {% assign variant_color = variant.option1 %}
+            {% assign variant_color = variant_candidate.option1 %}
           {% when 2 %}
-            {% assign variant_color = variant.option2 %}
+            {% assign variant_color = variant_candidate.option2 %}
           {% when 3 %}
-            {% assign variant_color = variant.option3 %}
+            {% assign variant_color = variant_candidate.option3 %}
         {% endcase %}
 
-        {% comment %} Normalize variant color for comparison {% endcomment %}
         {% assign variant_color_normalized = variant_color | downcase | strip | replace: ' ', '-' | replace: "'", '' | replace: '.', '' | replace: ',', '' %}
-
-        {% comment %} Check if this variant matches our target color {% endcomment %}
         {% if variant_color_normalized == color_value_normalized %}
-          {% comment %} Priority 1: Use variant.featured_image {% endcomment %}
-          {% if variant.featured_image %}
-            {% assign image_url = variant.featured_image | image_url: width: width, height: height, crop: crop %}
-            {% break %}
-          {% comment %} Priority 2: Use variant.image {% endcomment %}
-          {% elsif variant.image %}
-            {% assign image_url = variant.image | image_url: width: width, height: height, crop: crop %}
-            {% break %}
-          {% endif %}
+          {% assign target_variant = variant_candidate %}
+          {% break %}
         {% endif %}
       {% endif %}
     {% endfor %}
 
-    {% comment %} Second pass: If no available variant found, look for any variant with matching color {% endcomment %}
-    {% if image_url == blank %}
-      {% for variant in product.variants %}
-        {% comment %} Get the color option value for this variant {% endcomment %}
+    {% if target_variant == blank %}
+      {% for variant_candidate in product.variants %}
         {% case color_option_position %}
           {% when 1 %}
-            {% assign variant_color = variant.option1 %}
+            {% assign variant_color = variant_candidate.option1 %}
           {% when 2 %}
-            {% assign variant_color = variant.option2 %}
+            {% assign variant_color = variant_candidate.option2 %}
           {% when 3 %}
-            {% assign variant_color = variant.option3 %}
+            {% assign variant_color = variant_candidate.option3 %}
         {% endcase %}
 
-        {% comment %} Normalize variant color for comparison {% endcomment %}
         {% assign variant_color_normalized = variant_color | downcase | strip | replace: ' ', '-' | replace: "'", '' | replace: '.', '' | replace: ',', '' %}
-
-        {% comment %} Check if this variant matches our target color {% endcomment %}
         {% if variant_color_normalized == color_value_normalized %}
-          {% comment %} Priority 1: Use variant.featured_image {% endcomment %}
-          {% if variant.featured_image %}
-            {% assign image_url = variant.featured_image | image_url: width: width, height: height, crop: crop %}
-            {% break %}
-          {% comment %} Priority 2: Use variant.image {% endcomment %}
-          {% elsif variant.image %}
-            {% assign image_url = variant.image | image_url: width: width, height: height, crop: crop %}
-            {% break %}
-          {% endif %}
+          {% assign target_variant = variant_candidate %}
+          {% break %}
         {% endif %}
       {% endfor %}
     {% endif %}
   {% endif %}
 {% endif %}
 
-{% comment %} Step 2: Fallback to existing product-color-utils logic if no variant image found {% endcomment %}
-{% if image_url == blank %}
+{% if target_variant != blank and target_variant.featured_image %}
+  {% assign image_url = target_variant.featured_image | image_url: width: width, height: height, crop: crop %}
+{% else %}
   {% capture fallback_image_url %}{% render 'product-color-utils',
     with: 'get_color_image',
     product: product,
     color_value: color_value,
+    variant: target_variant,
     image_type: image_type,
     width: width,
     height: height,
@@ -131,5 +101,4 @@
   {% assign image_url = fallback_image_url | strip %}
 {% endif %}
 
-{% comment %} Output the image_url variable directly to make it accessible to the parent template {% endcomment %}
 {%- if image_url != blank -%}{{ image_url }}{%- endif -%}

--- a/snippets/product-color-utils.liquid
+++ b/snippets/product-color-utils.liquid
@@ -182,213 +182,84 @@
 {% endcomment %}
 {% capture get_color_image %}
   {% assign image_url = '' %}
+  {% assign resolved_reference_id = reference_id | default: '' | strip %}
 
-  {% if color_value != blank and product != blank %}
-    {% comment %} Step 1: Normalize color value {% endcomment %}
-    {% assign color_value_normalized = color_value | downcase | strip | replace: ' ', '-' | replace: "'", "" | replace: ".", "" | replace: ",", "" %}
-    {% assign reference_id = '' %}
+  {% if product != blank %}
+    {% if resolved_reference_id == blank and variant != blank and variant.sku != blank %}
+      {% assign sku_parts = variant.sku | split: '-' %}
+      {% assign reference_index = sku_parts.size | minus: 2 %}
+      {% if reference_index >= 0 %}
+        {% assign sku_reference_id = sku_parts[reference_index] | strip %}
+        {% assign sku_reference_number = sku_reference_id | plus: 0 %}
+        {% if sku_reference_number > 0 %}
+          {% assign resolved_reference_id = sku_reference_id %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
 
-    {% comment %} Step 2: Try to find reference ID from metafields {% endcomment %}
-    {% if product.metafields.custom.color.value != blank %}
+    {% if resolved_reference_id == blank and color_value != blank and product.metafields.custom.color.value != blank %}
+      {% assign color_value_normalized = color_value | downcase | strip | replace: ' ', '-' | replace: "'", '' | replace: '.', '' | replace: ',', '' %}
       {% for color_item in product.metafields.custom.color.value %}
-        {%- comment -%}
-          Locale-safe match: metaobject `name` field is translatable, fall back to
-          system.handle (root part before trailing -N) which is never translated.
-        {%- endcomment -%}
-        {%- assign handle_root = color_item.system.handle | split: '-' | first | downcase -%}
+        {% assign handle_root = color_item.system.handle | split: '-' | first | downcase %}
         {% if color_item.name == color_value_normalized or handle_root == color_value_normalized %}
-          {% assign reference_id = color_item.reference_id %}
+          {% assign resolved_reference_id = color_item.reference_id | strip %}
           {% break %}
         {% endif %}
       {% endfor %}
     {% endif %}
 
-    {% comment %} Store first model image and first image for fallback {% endcomment %}
-    {% assign first_model_image = nil %}
-    {% assign first_image = nil %}
+    {% if resolved_reference_id != blank %}
+      {% assign reference_token = '-' | append: resolved_reference_id | append: '-' %}
+      {% assign hero_media = nil %}
+      {% assign model_media = nil %}
+      {% assign model_sequence_media = nil %}
+      {% assign detail_media = nil %}
+      {% assign back_variant_media = nil %}
+      {% assign back_media = nil %}
+      {% assign lowest_model_sequence = 999 %}
+      {% assign lowest_detail_sequence = 999 %}
 
-    {% comment %} Step 3: Find image by reference ID and image type {% endcomment %}
-    {% if reference_id != '' %}
-      {% if image_type == 'M' %}
-        {% comment %} Look for model images (M) with exact color reference ID {% endcomment %}
-        {% assign lowest_sequence = 999 %}
-        {% assign found_model_image = false %}
-
-        {% comment %} First look for model images without sequence (just -M) {% endcomment %}
-        {% for media in product.media %}
-          {% assign media_src = media.src | default: '' %}
-          {% assign parsed_url = media_src | split: '/' | last %}
-
-          {% comment %} Track first model image for any color (fallback) {% endcomment %}
-          {% if first_model_image == nil and parsed_url contains '-M' %}
-            {% unless parsed_url contains '-M_' %}
-              {% assign first_model_image = media %}
-            {% endunless %}
-          {% endif %}
-
-          {% comment %} Track first image (final fallback) {% endcomment %}
-          {% if first_image == nil %}
-            {% assign first_image = media %}
-          {% endif %}
-
-          {% if parsed_url contains reference_id %}
-            {% if parsed_url contains '-M' %}
-              {% unless parsed_url contains '-M_' %}
-                {% assign image_url = media.preview_image | image_url: width: width, height: height, crop: crop %}
-                {% assign found_model_image = true %}
-                {% break %}
-              {% endunless %}
-            {% endif %}
-          {% endif %}
-        {% endfor %}
-
-        {% comment %} If no model image without sequence found, look for one with lowest sequence {% endcomment %}
-        {% unless found_model_image %}
-          {% assign best_model_media = nil %}
-          {% for media in product.media %}
-            {% assign media_src = media.src | default: '' %}
-            {% assign parsed_url = media_src | split: '/' | last %}
-            {% if parsed_url contains reference_id and parsed_url contains '-M_' %}
-              {% assign sequence_part = parsed_url | split: '-M_' | last | split: '.' | first %}
-              {% assign sequence_number = sequence_part | plus: 0 %}
-
-              {% comment %} Only update if this sequence is lower than current lowest {% endcomment %}
-              {% if sequence_number > 0 and sequence_number < lowest_sequence %}
-                {% assign lowest_sequence = sequence_number %}
-                {% assign best_model_media = media %}
-                {% assign found_model_image = true %}
-              {% endif %}
-            {% endif %}
-          {% endfor %}
-
-          {% comment %} Set the image URL from the best model media found {% endcomment %}
-          {% if best_model_media %}
-            {% assign image_url = best_model_media.preview_image | image_url: width: width, height: height, crop: crop %}
-          {% endif %}
-        {% endunless %}
-
-        {% comment %}
-          When the product has no model (-M) image for this color reference_id
-          (common for shoes), fall back to the typed-priority loop (H -> BV -> B -> D)
-          on the SAME reference_id instead of dropping into Step 5, which would
-          otherwise return the first media item containing the ref_id in admin
-          drag-drop order (e.g. a sole or close-up shot).
-        {% endcomment %}
-        {% if image_url == '' %}
-          {% assign fallback_types = 'H,BV,B,D' | split: ',' %}
-          {% for type in fallback_types %}
-            {% if image_url == '' %}
-              {% for media in product.media %}
-                {% assign media_src = media.src | default: '' %}
-                {% assign parsed_url = media_src | split: '/' | last %}
-                {% assign type_code = '-' | append: type %}
-                {% if parsed_url contains reference_id and parsed_url contains type_code %}
-                  {% assign image_url = media.preview_image | image_url: width: width, height: height, crop: crop %}
-                  {% break %}
-                {% endif %}
-              {% endfor %}
-            {% endif %}
-          {% endfor %}
-        {% endif %}
-      {% else %}
-        {% comment %} Look for specific image type or use priority order {% endcomment %}
-        {% assign image_types = image_type | default: 'H,B,BV,D' | split: ',' %}
-
-        {% for type in image_types %}
-          {% if image_url == '' %}
-            {% for media in product.media %}
-              {% assign media_src = media.src | default: '' %}
-              {% assign parsed_url = media_src | split: '/' | last %}
-
-              {% comment %} Track first model image for any color (fallback) {% endcomment %}
-              {% if first_model_image == nil and parsed_url contains '-M' %}
-                {% unless parsed_url contains '-M_' %}
-                  {% assign first_model_image = media %}
-                {% endunless %}
-              {% endif %}
-
-              {% comment %} Track first image (final fallback) {% endcomment %}
-              {% if first_image == nil %}
-                {% assign first_image = media %}
-              {% endif %}
-
-              {% comment %} Check if the image contains both the reference_id and the current image type {% endcomment %}
-              {% assign type_code = '-' | append: type %}
-              {% if parsed_url contains reference_id and parsed_url contains type_code %}
-                {% assign image_url = media.preview_image | image_url: width: width, height: height, crop: crop %}
-                {% break %}
-              {% endif %}
-            {% endfor %}
-          {% endif %}
-        {% endfor %}
-      {% endif %}
-    {% else %}
-      {% comment %} If no reference ID, still track first model image and first image for fallback {% endcomment %}
       {% for media in product.media %}
         {% assign media_src = media.src | default: '' %}
-        {% assign parsed_url = media_src | split: '/' | last %}
+        {% assign filename = media_src | split: '/' | last | split: '?' | first %}
+        {% if filename contains reference_token %}
+          {% assign type_token = filename | split: reference_token | last | split: '.' | first %}
+          {% assign type_parts = type_token | split: '_' %}
+          {% assign type_name = type_parts.first %}
+          {% assign type_sequence = 0 %}
+          {% if type_parts.size > 1 %}
+            {% assign type_sequence = type_parts[1] | plus: 0 %}
+          {% endif %}
 
-        {% comment %} Track first model image for any color (fallback) {% endcomment %}
-        {% if first_model_image == nil and parsed_url contains '-M' %}
-          {% unless parsed_url contains '-M_' %}
-            {% assign first_model_image = media %}
-          {% endunless %}
-        {% endif %}
-
-        {% comment %} Track first image (final fallback) {% endcomment %}
-        {% if first_image == nil %}
-          {% assign first_image = media %}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
-
-    {% comment %} Step 4: If no image found by reference ID, try by color name {% endcomment %}
-    {% if image_url == '' %}
-      {% for media in product.media %}
-        {% assign media_src = media.src | default: '' %}
-        {% assign parsed_url = media_src | split: '/' | last %}
-
-        {% if parsed_url contains color_value_normalized %}
-          {% assign image_url = media.preview_image | image_url: width: width, height: height, crop: crop %}
-          {% break %}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
-
-    {% comment %} Step 5: If still no image found, try to find any image with a color reference pattern {% endcomment %}
-    {% if image_url == '' and reference_id != '' %}
-      {% assign reference_pattern = reference_id | slice: 0, 3 %}
-      {% for media in product.media %}
-        {% assign media_src = media.src | default: '' %}
-        {% assign parsed_url = media_src | split: '/' | last %}
-
-        {% if parsed_url contains reference_pattern %}
-          {% assign image_url = media.preview_image | image_url: width: width, height: height, crop: crop %}
-          {% break %}
+          {% if type_name == 'H' and hero_media == nil %}
+            {% assign hero_media = media %}
+          {% elsif type_name == 'M' %}
+            {% if type_sequence > 0 %}
+              {% if type_sequence < lowest_model_sequence %}
+                {% assign lowest_model_sequence = type_sequence %}
+                {% assign model_sequence_media = media %}
+              {% endif %}
+            {% elsif model_media == nil %}
+              {% assign model_media = media %}
+            {% endif %}
+          {% elsif type_name == 'D' and type_sequence > 0 %}
+            {% if type_sequence < lowest_detail_sequence %}
+              {% assign lowest_detail_sequence = type_sequence %}
+              {% assign detail_media = media %}
+            {% endif %}
+          {% elsif type_name == 'BV' and back_variant_media == nil %}
+            {% assign back_variant_media = media %}
+          {% elsif type_name == 'B' and back_media == nil %}
+            {% assign back_media = media %}
+          {% endif %}
         {% endif %}
       {% endfor %}
+
+      {% assign selected_media = hero_media | default: model_media | default: model_sequence_media | default: detail_media | default: back_variant_media | default: back_media %}
+      {% if selected_media != blank %}
+        {% assign image_url = selected_media.preview_image | image_url: width: width, height: height, crop: crop %}
+      {% endif %}
     {% endif %}
-
-    {% comment %}
-      Steps 6-8 are generic fallbacks (not color-specific).
-      Skipped when `strict` is true so callers can detect "no real color match".
-    {% endcomment %}
-    {% unless strict %}
-      {% comment %} Step 6: If still no image found, fallback to first model image of any color {% endcomment %}
-      {% if image_url == '' and first_model_image != nil %}
-        {% assign image_url = first_model_image.preview_image | image_url: width: width, height: height, crop: crop %}
-      {% endif %}
-
-      {% comment %} Step 7: If still no image found, fallback to product featured image {% endcomment %}
-      {% if image_url == '' and product.featured_image %}
-        {% assign image_url = product.featured_image | image_url: width: width, height: height, crop: crop %}
-      {% endif %}
-
-      {% comment %} Step 8: Final fallback - use any random image from the product {% endcomment %}
-      {% if image_url == '' and first_image != nil %}
-        {% assign image_url = first_image.preview_image | image_url: width: width, height: height, crop: crop %}
-      {% endif %}
-    {% endunless %}
   {% endif %}
 
   {{ image_url }}

--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -476,6 +476,7 @@
           {% capture thumbnail_url %}{% render 'get-variant-color-image',
             product: product,
             color_value: color_value,
+            variant: value.variant,
             width: 80,
             height: 80,
             crop: 'center',

--- a/snippets/swatch.liquid
+++ b/snippets/swatch.liquid
@@ -24,8 +24,7 @@
 >
   {%- if thumbnail_url != blank -%}
     <img src="{{ thumbnail_url }}" alt="" class="swatch-thumbnail" width="50" height="50" loading="lazy">
-  {%- else -%}
-    {%- comment -%} Show placeholder when no thumbnail is available {%- endcomment -%}
+  {%- elsif swatch.image == blank and swatch.color == blank -%}
     <div class="swatch-thumbnail-placeholder">
       {{ 'product-apparel-2' | placeholder_svg_tag: 'swatch-placeholder-svg' }}
     </div>


### PR DESCRIPTION
## Summary

- apply the canonical color thumbnail fallback order across PDP, product cards, cart, notifications, and order history
- resolve color references from the selected variant SKU before falling back to color metaobjects
- support Shopify-normalized duplicate suffixes such as `M_1_2` when filtering PDP gallery media
- fall back to native color swatches or placeholders without leaking another color's image
- remove invalid blank defaults from the `info-box` section schema so product and collection templates upload and render on fresh draft themes
- update the color thumbnail documentation and regression coverage

## Root cause

Some color variants do not have a direct featured image or complete color metadata, so the previous resolver could hide the color or display an image belonging to another color. ALMA media filenames also contain normalized duplicate suffixes such as `M_1_2`, which the parser did not recognize.

Separately, the `info-box` schema defined blank text defaults. Shopify accepted the draft creation with file errors, leaving product and collection routes returning 404.

## Validation

- `pnpm exec vitest run assets/product-utils.test.js`: 23 tests passed
- `info-box` schema parses with zero blank defaults
- draft theme `202068754764` uploaded successfully
- ALMA PDP and `/collections/all` return HTTP 200 on the draft theme
- browser verification confirms the ALMA black variant renders 8 desktop and 8 mobile images, all reference `269`, ordered `H -> M_1_2 -> ... -> M_7_2`
- the nine orphan EComposer templates were ignored only for draft verification and are not modified by this PR
