### PR TITLE
fix: keep footer language dropdown above sections

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -72,6 +72,11 @@
 
   /* Footer localization: compact trigger sized for footer column.
      Shared dropdown styles live in component-localization-form.css */
+  .footer__content-top {
+    position: relative;
+    z-index: 2;
+  }
+
   .footer__localization {
     align-items: flex-start;
     gap: 1.5rem;


### PR DESCRIPTION
## What changed
- Raise the footer content-top stacking context above the preceding EComposer section.

## Why
The language dropdown opens upward from the footer, but the preceding EComposer section creates a positioned stacking layer that painted over the dropdown. Raising the footer content-top to `z-index: 2` keeps the existing dropdown panel visible without changing its localization behavior.

## Verification
- Shopify Liquid validator: `sections/footer.liquid` passed.
- Theme Check: no offenses reported for `sections/footer.liquid`.
- In-app storefront verification: injected the same style, opened the language dropdown, and confirmed hit-testing places the dropdown above the overlapping section.
