### PR TITLE
Fix invalid blog Liquid boolean assignments

### DIFF
--- a/sections/blog-videos.liquid
+++ b/sections/blog-videos.liquid
@@ -188,9 +188,9 @@
          data-total-articles="{{ blogs.video.articles.size }}">
       <div class="no-results-message">{{ 'blogs.main_blog.no_results' | t }}</div>
       {%- for article in blogs.video.articles -%}
-        {%- assign _has_visible_tag = false -%}
+        {%- assign has_visible_tag = false -%}
         {%- if article.tags.size > 0 -%}
-          {%- assign _has_visible_tag = true -%}
+          {%- assign has_visible_tag = true -%}
         {%- endif -%}
         <div
           class="blog-videos-grid__article article{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
@@ -257,7 +257,7 @@
               </div>
 
               <div class="article-video-card__content">
-                {% if _has_visible_tag %}
+                {% if has_visible_tag %}
                   <div class="article-card__tags">
                     {% for tag in article.tags %}
                       {%- render 'article-tag-label', tag: tag, class: 'article-card__tag' -%}

--- a/sections/blog-videos.liquid
+++ b/sections/blog-videos.liquid
@@ -188,7 +188,10 @@
          data-total-articles="{{ blogs.video.articles.size }}">
       <div class="no-results-message">{{ 'blogs.main_blog.no_results' | t }}</div>
       {%- for article in blogs.video.articles -%}
-        {%- assign _has_visible_tag = article.tags.size > 0 -%}
+        {%- assign _has_visible_tag = false -%}
+        {%- if article.tags.size > 0 -%}
+          {%- assign _has_visible_tag = true -%}
+        {%- endif -%}
         <div
           class="blog-videos-grid__article article{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
           {% if settings.animations_reveal_on_scroll %}

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -23,7 +23,10 @@
       assign ratio = media_aspect_ratio
     endif
 
-    assign _has_visible_tag = article.tags.size > 0
+    assign _has_visible_tag = false
+    if article.tags.size > 0
+      assign _has_visible_tag = true
+    endif
   -%}
   <div class="article-card-wrapper card-wrapper" style="container-type: inline-size;">
     <div class="article-card">

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -23,9 +23,9 @@
       assign ratio = media_aspect_ratio
     endif
 
-    assign _has_visible_tag = false
+    assign has_visible_tag = false
     if article.tags.size > 0
-      assign _has_visible_tag = true
+      assign has_visible_tag = true
     endif
   -%}
   <div class="article-card-wrapper card-wrapper" style="container-type: inline-size;">
@@ -45,12 +45,12 @@
             </a>
             {% comment %}theme-check-enable ImgLazyLoading{% endcomment %}
 
-            {% if _has_visible_tag %}
+            {% if has_visible_tag %}
               <div class="article-card__image-tags">
-                {%- assign _img_tag_count = 0 -%}
+                {%- assign img_tag_count = 0 -%}
                 {% for tag in article.tags %}
-                  {%- if _img_tag_count >= 3 -%}{%- break -%}{%- endif -%}
-                  {%- assign _img_tag_count = _img_tag_count | plus: 1 -%}
+                  {%- if img_tag_count >= 3 -%}{%- break -%}{%- endif -%}
+                  {%- assign img_tag_count = img_tag_count | plus: 1 -%}
                   {%- render 'article-tag-label', tag: tag, class: 'article-card__image-tag' -%}
                 {% endfor %}
               </div>
@@ -60,7 +60,7 @@
       {%- endif -%}
 
       <div class="article-card__content">
-        {% if _has_visible_tag %}
+        {% if has_visible_tag %}
           <div class="article-card__tags">
             {% for tag in article.tags %}
               {%- render 'article-tag-label', tag: tag, class: 'article-card__tag' -%}

--- a/snippets/article-tag-label.liquid
+++ b/snippets/article-tag-label.liquid
@@ -14,28 +14,28 @@
 {% endcomment %}
 
 {%- liquid
-  assign _tag = tag | default: ''
-  assign _class = class | default: 'article-card__tag'
-  assign _prefix = prefix | default: '#'
-  assign _tag_lc = _tag | downcase
-  assign _slice4 = _tag_lc | slice: 0, 4
-  assign _label = _tag
-  if _slice4 == 'cat:'
+  assign tag_value = tag | default: ''
+  assign tag_class = class | default: 'article-card__tag'
+  assign tag_prefix = prefix | default: '#'
+  assign tag_lowercase = tag_value | downcase
+  assign tag_prefix_length = tag_lowercase | slice: 0, 4
+  assign tag_label = tag_value
+  if tag_prefix_length == 'cat:'
     # Resolve the chip label via the `blog_category` metaobject so it can be
     # translated through Shopify's native Translate & Adapt. The metaobject
     # entry handle matches the `cat:<handle>` slug. Fall back to a humanized
     # label if no entry exists for the slug.
-    assign _slug = _tag | remove_first: 'cat:' | remove_first: 'CAT:' | remove_first: 'Cat:' | strip | downcase | handleize
-    assign _entry = shop.metaobjects.blog_category[_slug]
-    if _entry != blank and _entry.name != blank
-      assign _label = _entry.name
+    assign category_slug = tag_value | remove_first: 'cat:' | remove_first: 'CAT:' | remove_first: 'Cat:' | strip | downcase | handleize
+    assign category_entry = shop.metaobjects.blog_category[category_slug]
+    if category_entry != blank and category_entry.name != blank
+      assign tag_label = category_entry.name
     else
-      assign _label = _tag | remove_first: 'cat:' | remove_first: 'CAT:' | remove_first: 'Cat:' | strip | capitalize
+      assign tag_label = tag_value | remove_first: 'cat:' | remove_first: 'CAT:' | remove_first: 'Cat:' | strip | capitalize
     endif
   endif
 -%}
 {%- if href != blank -%}
-  <a class="{{ _class }}" href="{{ href }}">{{ _prefix }}{{ _label }}</a>
+  <a class="{{ tag_class }}" href="{{ href }}">{{ tag_prefix }}{{ tag_label }}</a>
 {%- else -%}
-  <span class="{{ _class }}">{{ _prefix }}{{ _label }}</span>
+  <span class="{{ tag_class }}">{{ tag_prefix }}{{ tag_label }}</span>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- replace invalid Liquid comparison assignments in `snippets/article-card.liquid`
- replace invalid Liquid comparison assignments in `sections/blog-videos.liquid`

## Validation
- Vitest: 23/23 passed
- `git diff --check` passed
- confirmed no remaining `assign _has_visible_tag = article.tags.size > 0` expressions

This follows merged PR #30, which exposed the invalid syntax in the production base branch.