### PR TITLE
fix(search): prioritize products in predictive results

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -348,6 +348,7 @@ predictive-search[loading] .predictive-search__results-groups-wrapper ~ .predict
 }
 
 .nf__predictive-search__result-group .predictive-search__list-item-articles .predictive-search__item {
+  min-width: 0;
   padding: 0;
   flex: 1;
 }
@@ -357,10 +358,10 @@ predictive-search[loading] .predictive-search__results-groups-wrapper ~ .predict
   font-weight: 400;
   line-height: 1.125rem;
   color: var(--color-black);  /* #000000 */
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 300px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  max-width: 100%;
   display: block;
   padding: 0;
 }
@@ -374,6 +375,7 @@ predictive-search[loading] .predictive-search__results-groups-wrapper ~ .predict
   line-height: 1.125rem;
   color: var(--color-gray-700);  /* #666666 */
   white-space: nowrap;
+  flex-shrink: 0;
   min-width: 160px;
   justify-content: flex-end;
 }
@@ -434,10 +436,10 @@ predictive-search[loading] .predictive-search__results-groups-wrapper ~ .predict
   font-weight: 600;
   line-height: 1.125rem;
   color: rgb(var(--color-base-foreground));
-  max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
 }
 
 .nf__predictive-search__result-group .predictive-search__list-item-products .predictive-search__item .meta {

--- a/assets/predictive-search.js
+++ b/assets/predictive-search.js
@@ -317,7 +317,8 @@ class PredictiveSearch extends SearchForm {
       })
       .filter(({ items }) => items.length);
     const resultCount = resultGroups.reduce((count, { items }) => count + items.length, 0);
-    const allResultsUrl = `${window.Shopify?.routes?.search_url || routes.search_url || '/search'}?q=${encodeURIComponent(this.searchTerm)}`;
+    const allResultsUrl = new URL(routes.search_url, window.location.origin);
+    allResultsUrl.searchParams.set('q', this.searchTerm);
 
     const html = template`
     <div class="nf__predictive-search-results">

--- a/assets/predictive-search.js
+++ b/assets/predictive-search.js
@@ -20,6 +20,7 @@ class PredictiveSearch extends SearchForm {
       categories: this.decodeHtmlEntities(window.theme?.strings?.search?.categories || 'Categories'),
       articles: this.decodeHtmlEntities(window.theme?.strings?.search?.articles || 'Articles'),
       products: this.decodeHtmlEntities(window.theme?.strings?.search?.products || 'Products'),
+      view_all_results: this.decodeHtmlEntities(window.theme?.strings?.search?.view_all_results || 'View all results'),
       no_results: this.decodeHtmlEntities(window.theme?.strings?.search?.no_results || 'No results found for {{ terms }}. Check the spelling or use a different word or phrase.'),
       no_results_suggestion: this.decodeHtmlEntities(window.theme?.strings?.search?.no_results_suggestion || 'Try checking your spelling or using different words.')
     };
@@ -150,7 +151,7 @@ class PredictiveSearch extends SearchForm {
 
     const moveUp = direction === 'up';
     const selectedElement = this.querySelector('[aria-selected="true"]');
-    const allVisibleElements = Array.from(this.querySelectorAll('li, button.predictive-search__item')).filter(
+    const allVisibleElements = Array.from(this.querySelectorAll('[role="option"]')).filter(
       (element) => element.offsetParent !== null,
     );
 
@@ -181,8 +182,9 @@ class PredictiveSearch extends SearchForm {
   }
 
   selectOption() {
-    const selectedOption = this.querySelector('[aria-selected="true"] a, button[aria-selected="true"]');
-    if (selectedOption) selectedOption.click();
+    const selectedOption = this.querySelector('[aria-selected="true"]');
+    const selectedLink = selectedOption?.querySelector('a') || selectedOption;
+    if (selectedLink) selectedLink.click();
   }
 
   getMarkupFromResults(results) {
@@ -206,7 +208,7 @@ class PredictiveSearch extends SearchForm {
     };
 
     // Check if we have any results
-    const hasResults = ['collections', 'articles', 'products'].some(type => {
+    const hasResults = ['collections', 'articles', 'products'].some((type) => {
       const items = results[type] || [];
       return items.length > 0;
     });
@@ -284,6 +286,39 @@ class PredictiveSearch extends SearchForm {
       return `${day}.${month}.${year}`;
     }
 
+    const normalizedSearchTerm = this.searchTerm.trim().toLocaleLowerCase();
+    const resultGroups = ['products', 'collections', 'articles']
+      .map((type) => {
+        const seen = new Set();
+        const seenArticleUrls = new Set();
+        const seenArticleTitles = new Set();
+        const items = (results[type] || []).filter((item) => {
+          const url = (item.url || '').split('?')[0].replace(/\/$/, '').toLocaleLowerCase();
+          const title = (item.title || '').trim().toLocaleLowerCase();
+          const key = url || title;
+          if (!key || seen.has(key)) return false;
+          if (type === 'articles' && (seenArticleUrls.has(url) || seenArticleTitles.has(title))) return false;
+          seen.add(key);
+          if (type === 'articles') {
+            seenArticleUrls.add(url);
+            seenArticleTitles.add(title);
+          }
+          return true;
+        });
+        if (type !== 'products') return { type, items };
+        return {
+          type,
+          items: items.sort((a, b) => {
+            const aExact = (a.title || '').trim().toLocaleLowerCase() === normalizedSearchTerm;
+            const bExact = (b.title || '').trim().toLocaleLowerCase() === normalizedSearchTerm;
+            return Number(bExact) - Number(aExact);
+          }),
+        };
+      })
+      .filter(({ items }) => items.length);
+    const resultCount = resultGroups.reduce((count, { items }) => count + items.length, 0);
+    const allResultsUrl = `${window.Shopify?.routes?.search_url || routes.search_url || '/search'}?q=${encodeURIComponent(this.searchTerm)}`;
+
     const html = template`
     <div class="nf__predictive-search-results">
       <div class="nf__predictive-search__results-groups-wrapper" id="predictive-search-results-groups-wrapper">
@@ -294,21 +329,20 @@ class PredictiveSearch extends SearchForm {
               <p class="nf__predictive-search__no-results-suggestion">${this.translations.no_results_suggestion}</p>
             </div>
           ` :
-          ['collections', 'articles', 'products']
-            .map((type) => {
-              const items = results[type] || [];
-              if (!items.length) return null;
+          resultGroups
+            .map(({ type, items }) => {
               return hyperHTML.wire(items)`
                 <div class="nf__predictive-search__result-group">
                   <h2>
                     ${categoryLabelMap[type]}
                   </h2>
-                  <ul class="predictive-search__result-list list-unstyled" role="list">
-                    ${items.map((item) => {
+                  <ul class="predictive-search__result-list list-unstyled" role="listbox" aria-label="${categoryLabelMap[type]}">
+                    ${items.map((item, itemIndex) => {
+                    const optionId = `predictive-search-${type}-${itemIndex}`;
                     if (type === 'collections')
                       return hyperHTML.wire(item)`
-                        <li class="predictive-search__list-item-collections" role="option">
-                          <a href="${item.url}" class="predictive-search__item" tabindex="-1">
+                        <li id="${optionId}" class="predictive-search__list-item-collections" role="option" aria-selected="false">
+                          <a href="${item.url}" class="predictive-search__item" tabindex="-1" aria-label="${item.title}">
                             <span class="predictive-search__item-heading">${item.title}</span>
                           </a>
                         </li>
@@ -316,8 +350,8 @@ class PredictiveSearch extends SearchForm {
 
                     if (type === 'articles')
                       return hyperHTML.wire(item)`
-                        <li class="predictive-search__list-item-articles" role="option">
-                          <a href="${item.url}" class="predictive-search__item" tabindex="-1">
+                        <li id="${optionId}" class="predictive-search__list-item-articles" role="option" aria-selected="false">
+                          <a href="${item.url}" class="predictive-search__item" tabindex="-1" aria-label="${item.title}">
                             <span class="predictive-search__item-heading">${item.title}</span>
                           </a>
                           <div class="article-meta">
@@ -343,8 +377,8 @@ class PredictiveSearch extends SearchForm {
                     discountPrice = parseFloat(discountPrice) || 0;
 
                     return hyperHTML.wire(item)`
-                      <li class="predictive-search__list-item-products" role="option">
-                        <a href="${item.url}" class="predictive-search__item" tabindex="-1">
+                      <li id="${optionId}" class="predictive-search__list-item-products" role="option" aria-selected="false">
+                        <a href="${item.url}" class="predictive-search__item" tabindex="-1" aria-label="${item.title}">
                           <div class="product">
                             <img src="${item.image}"/>
                             <h3>${item.title}
@@ -390,6 +424,16 @@ class PredictiveSearch extends SearchForm {
           })
           .filter(Boolean)}
       </div>
+      ${resultCount ? hyperHTML.wire()`
+        <a
+          id="predictive-search-view-all"
+          class="nf__predictive-search__view-all-button button button--primary"
+          href="${allResultsUrl}"
+          role="option"
+          aria-selected="false"
+          tabindex="-1"
+        >${this.translations.view_all_results}</a>
+      ` : ''}
     </div>
   `;
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -414,6 +414,7 @@
         cart_change_url: '{{ routes.cart_change_url }}',
         cart_update_url: '{{ routes.cart_update_url }}',
         cart_url: '{{ routes.cart_url }}',
+        search_url: '{{ routes.search_url }}',
         predictive_search_url: '{{ routes.predictive_search_url }}',
       };
 
@@ -525,6 +526,10 @@
     <script src="{{ 'search-form.js' | asset_url }}" defer="defer"></script>
 
     {%- if settings.predictive_search_enabled -%}
+      {%- assign search_view_all_results = 'templates.search.view_all_results' | t -%}
+      {%- if search_view_all_results contains 'Translation missing' -%}
+        {%- assign search_view_all_results = 'View all results' -%}
+      {%- endif -%}
       <script>
         window.theme = window.theme || {};
         window.theme.strings = window.theme.strings || {};
@@ -532,7 +537,7 @@
           categories: `{{ 'templates.search.categories' | t | escape }}`,
           articles: `{{ 'templates.search.articles' | t | escape }}`,
           products: `{{ 'templates.search.products' | t | escape }}`,
-          view_all_results: `{{ 'templates.search.view_all_results' | t | escape }}`,
+          view_all_results: `{{ search_view_all_results | escape }}`,
           no_results: `{{ 'templates.search.no_results' | t | escape }}`,
           no_results_suggestion: `{{ 'templates.search.no_results_suggestion' | t | escape }}`
         };

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -532,6 +532,7 @@
           categories: `{{ 'templates.search.categories' | t | escape }}`,
           articles: `{{ 'templates.search.articles' | t | escape }}`,
           products: `{{ 'templates.search.products' | t | escape }}`,
+          view_all_results: `{{ 'templates.search.view_all_results' | t | escape }}`,
           no_results: `{{ 'templates.search.no_results' | t | escape }}`,
           no_results_suggestion: `{{ 'templates.search.no_results_suggestion' | t | escape }}`
         };

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -1544,6 +1544,7 @@
       "page": "Page",
       "pages": "Pages",
       "products": "Products",
+      "view_all_results": "View all results",
       "results_pages_with_count": {
         "one": "{{ count }} page",
         "other": "{{ count }} pages"


### PR DESCRIPTION
## Summary
Fixes #37.

Predictive search now presents results in the requested order:

1. Products
2. Categories
3. Articles

Additional fixes:
- Exact product-title matches are promoted within product results.
- Duplicate article results are removed by normalized URL/title.
- Product and article titles wrap safely for long localized strings instead of clipping.
- Keyboard navigation uses stable accessible option IDs, including the view-all action.
- Added a localized “View all results” link.

## Verification
- `node --check assets/predictive-search.js`
- Locale JSON parse check passed.
- `git diff --check` passed.
- Shopify Theme Check was run, but the existing baseline reports 281 errors across unrelated legacy files, including missing section references and a pre-existing `general.search.heading` translation issue.
- Uploaded the fixed theme to unpublished draft `QA issue 37 after` (theme ID `203080139084`) with full files for rendering.
- Before/after browser evidence was captured on the canonical storefront preview with query `nort`.

## UI before / after
- Before: articles appeared above products, duplicate article titles were visible, and product titles were ellipsized.
- After: products appear first, duplicate articles are removed, and long titles wrap without overlap.

Temporary QA themes were deleted after verification.

### Locale-specific evidence
The replacement evidence comment uses the German storefront route `https://shop.northfinder.com/de` and query `nort`. It shows the before/after predictive-search ordering on the German market, with products moved ahead of articles after the fix.
