### PR TITLE
fix(social): support market-specific links

### DIFF
--- a/config/settings_data.context.bulgaria.json
+++ b/config/settings_data.context.bulgaria.json
@@ -13,6 +13,15 @@
   },
   "current": {
     "contact_email": "eshop@northfinder.bg",
+    "market_social_facebook_link": "",
+    "market_social_instagram_link": "",
+    "market_social_youtube_link": "",
+    "market_social_tiktok_link": "",
+    "market_social_twitter_link": "",
+    "market_social_pinterest_link": "",
+    "market_social_snapchat_link": "",
+    "market_social_tumblr_link": "",
+    "market_social_vimeo_link": "",
     "color_schemes": {
       "scheme-1": {
         "settings": {}

--- a/config/settings_data.context.croatia.json
+++ b/config/settings_data.context.croatia.json
@@ -13,6 +13,15 @@
   },
   "current": {
     "contact_email": "eshop@northfinder.hr",
+    "market_social_facebook_link": "",
+    "market_social_instagram_link": "",
+    "market_social_youtube_link": "",
+    "market_social_tiktok_link": "",
+    "market_social_twitter_link": "",
+    "market_social_pinterest_link": "",
+    "market_social_snapchat_link": "",
+    "market_social_tumblr_link": "",
+    "market_social_vimeo_link": "",
     "color_schemes": {
       "scheme-1": {
         "settings": {}

--- a/config/settings_data.context.czech.json
+++ b/config/settings_data.context.czech.json
@@ -12,6 +12,15 @@
     "market": "czech"
   },
   "current": {
+    "market_social_facebook_link": "",
+    "market_social_instagram_link": "",
+    "market_social_youtube_link": "",
+    "market_social_tiktok_link": "",
+    "market_social_twitter_link": "",
+    "market_social_pinterest_link": "",
+    "market_social_snapchat_link": "",
+    "market_social_tumblr_link": "",
+    "market_social_vimeo_link": "",
     "color_schemes": {
       "scheme-1": {
         "settings": {}

--- a/config/settings_data.context.romania.json
+++ b/config/settings_data.context.romania.json
@@ -12,6 +12,15 @@
     "market": "romania"
   },
   "current": {
+    "market_social_facebook_link": "",
+    "market_social_instagram_link": "",
+    "market_social_youtube_link": "",
+    "market_social_tiktok_link": "",
+    "market_social_twitter_link": "",
+    "market_social_pinterest_link": "",
+    "market_social_snapchat_link": "",
+    "market_social_tumblr_link": "",
+    "market_social_vimeo_link": "",
     "color_schemes": {
       "scheme-1": {
         "settings": {}

--- a/config/settings_data.context.slovenia.json
+++ b/config/settings_data.context.slovenia.json
@@ -14,6 +14,15 @@
   "current": {
     "contact_email": "eshop@northfinder.com",
     "contact_address": "Rastislavova 109, Lužianky 951 41, Slovakia",
+    "market_social_facebook_link": "",
+    "market_social_instagram_link": "",
+    "market_social_youtube_link": "",
+    "market_social_tiktok_link": "",
+    "market_social_twitter_link": "",
+    "market_social_pinterest_link": "",
+    "market_social_snapchat_link": "",
+    "market_social_tumblr_link": "",
+    "market_social_vimeo_link": "",
     "color_schemes": {
       "scheme-1": {
         "settings": {}

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1327,6 +1327,65 @@
         "content": "t:settings_schema.social-media.settings.header.content"
       },
       {
+        "type": "header",
+        "content": "Market-specific social links",
+        "info": "Optional overrides for the active market. Leave blank to use the global social link above."
+      },
+      {
+        "type": "text",
+        "id": "market_social_facebook_link",
+        "label": "t:settings_schema.social-media.settings.social_facebook_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_facebook_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_instagram_link",
+        "label": "t:settings_schema.social-media.settings.social_instagram_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_instagram_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_youtube_link",
+        "label": "t:settings_schema.social-media.settings.social_youtube_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_youtube_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_tiktok_link",
+        "label": "t:settings_schema.social-media.settings.social_tiktok_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_tiktok_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_twitter_link",
+        "label": "t:settings_schema.social-media.settings.social_twitter_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_twitter_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_pinterest_link",
+        "label": "t:settings_schema.social-media.settings.social_pinterest_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_pinterest_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_snapchat_link",
+        "label": "t:settings_schema.social-media.settings.social_snapchat_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_snapchat_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_tumblr_link",
+        "label": "t:settings_schema.social-media.settings.social_tumblr_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_tumblr_link.info"
+      },
+      {
+        "type": "text",
+        "id": "market_social_vimeo_link",
+        "label": "t:settings_schema.social-media.settings.social_vimeo_link.label",
+        "placeholder": "t:settings_schema.social-media.settings.social_vimeo_link.info"
+      },
+      {
         "type": "text",
         "id": "social_facebook_link",
         "label": "t:settings_schema.social-media.settings.social_facebook_link.label",

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -138,8 +138,44 @@
 
 <footer class="footer color-{{ section.settings.color_scheme }} gradient section-{{ section.id }}-padding border-0">
   {%- liquid
+  assign market_social_facebook_link = settings.social_facebook_link
+  if localization.market.handle != blank and settings.market_social_facebook_link != blank
+    assign market_social_facebook_link = settings.market_social_facebook_link
+  endif
+  assign market_social_instagram_link = settings.social_instagram_link
+  if localization.market.handle != blank and settings.market_social_instagram_link != blank
+    assign market_social_instagram_link = settings.market_social_instagram_link
+  endif
+  assign market_social_youtube_link = settings.social_youtube_link
+  if localization.market.handle != blank and settings.market_social_youtube_link != blank
+    assign market_social_youtube_link = settings.market_social_youtube_link
+  endif
+  assign market_social_tiktok_link = settings.social_tiktok_link
+  if localization.market.handle != blank and settings.market_social_tiktok_link != blank
+    assign market_social_tiktok_link = settings.market_social_tiktok_link
+  endif
+  assign market_social_twitter_link = settings.social_twitter_link
+  if localization.market.handle != blank and settings.market_social_twitter_link != blank
+    assign market_social_twitter_link = settings.market_social_twitter_link
+  endif
+  assign market_social_pinterest_link = settings.social_pinterest_link
+  if localization.market.handle != blank and settings.market_social_pinterest_link != blank
+    assign market_social_pinterest_link = settings.market_social_pinterest_link
+  endif
+  assign market_social_snapchat_link = settings.social_snapchat_link
+  if localization.market.handle != blank and settings.market_social_snapchat_link != blank
+    assign market_social_snapchat_link = settings.market_social_snapchat_link
+  endif
+  assign market_social_tumblr_link = settings.social_tumblr_link
+  if localization.market.handle != blank and settings.market_social_tumblr_link != blank
+    assign market_social_tumblr_link = settings.market_social_tumblr_link
+  endif
+  assign market_social_vimeo_link = settings.social_vimeo_link
+  if localization.market.handle != blank and settings.market_social_vimeo_link != blank
+    assign market_social_vimeo_link = settings.market_social_vimeo_link
+  endif
     assign has_social_icons = true
-    if settings.social_facebook_link == blank and settings.social_instagram_link == blank and settings.social_youtube_link == blank and settings.social_tiktok_link == blank and settings.social_twitter_link == blank and settings.social_pinterest_link == blank and settings.social_snapchat_link == blank and settings.social_tumblr_link == blank and settings.social_vimeo_link == blank
+    if market_social_facebook_link == blank and market_social_instagram_link == blank and market_social_youtube_link == blank and market_social_tiktok_link == blank and market_social_twitter_link == blank and market_social_pinterest_link == blank and market_social_snapchat_link == blank and market_social_tumblr_link == blank and market_social_vimeo_link == blank
       assign has_social_icons = false
     endif
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -104,9 +104,45 @@
   class="header-wrapper color-{{ section.settings.color_scheme }} gradient"
 >
   {%- liquid
+  assign market_social_facebook_link = settings.social_facebook_link
+  if localization.market.handle != blank and settings.market_social_facebook_link != blank
+    assign market_social_facebook_link = settings.market_social_facebook_link
+  endif
+  assign market_social_instagram_link = settings.social_instagram_link
+  if localization.market.handle != blank and settings.market_social_instagram_link != blank
+    assign market_social_instagram_link = settings.market_social_instagram_link
+  endif
+  assign market_social_youtube_link = settings.social_youtube_link
+  if localization.market.handle != blank and settings.market_social_youtube_link != blank
+    assign market_social_youtube_link = settings.market_social_youtube_link
+  endif
+  assign market_social_tiktok_link = settings.social_tiktok_link
+  if localization.market.handle != blank and settings.market_social_tiktok_link != blank
+    assign market_social_tiktok_link = settings.market_social_tiktok_link
+  endif
+  assign market_social_twitter_link = settings.social_twitter_link
+  if localization.market.handle != blank and settings.market_social_twitter_link != blank
+    assign market_social_twitter_link = settings.market_social_twitter_link
+  endif
+  assign market_social_pinterest_link = settings.social_pinterest_link
+  if localization.market.handle != blank and settings.market_social_pinterest_link != blank
+    assign market_social_pinterest_link = settings.market_social_pinterest_link
+  endif
+  assign market_social_snapchat_link = settings.social_snapchat_link
+  if localization.market.handle != blank and settings.market_social_snapchat_link != blank
+    assign market_social_snapchat_link = settings.market_social_snapchat_link
+  endif
+  assign market_social_tumblr_link = settings.social_tumblr_link
+  if localization.market.handle != blank and settings.market_social_tumblr_link != blank
+    assign market_social_tumblr_link = settings.market_social_tumblr_link
+  endif
+  assign market_social_vimeo_link = settings.social_vimeo_link
+  if localization.market.handle != blank and settings.market_social_vimeo_link != blank
+    assign market_social_vimeo_link = settings.market_social_vimeo_link
+  endif
     assign social_links = false
 
-    if settings.social_twitter_link != blank or settings.social_facebook_link != blank or settings.social_pinterest_link != blank or settings.social_instagram_link != blank or settings.social_youtube_link != blank or settings.social_vimeo_link != blank or settings.social_tiktok_link != blank or settings.social_tumblr_link != blank or settings.social_snapchat_link != blank
+    if market_social_twitter_link != blank or market_social_facebook_link != blank or market_social_pinterest_link != blank or market_social_instagram_link != blank or market_social_youtube_link != blank or market_social_vimeo_link != blank or market_social_tiktok_link != blank or market_social_tumblr_link != blank or market_social_snapchat_link != blank
       assign social_links = true
     endif
   -%}
@@ -264,15 +300,15 @@
       "logo": {{ settings.logo | image_url: width: 500 | prepend: "https:" | json }},
     {% endif %}
     "sameAs": [
-      {{ settings.social_twitter_link | json }},
-      {{ settings.social_facebook_link | json }},
-      {{ settings.social_pinterest_link | json }},
-      {{ settings.social_instagram_link | json }},
-      {{ settings.social_tiktok_link | json }},
-      {{ settings.social_tumblr_link | json }},
-      {{ settings.social_snapchat_link | json }},
-      {{ settings.social_youtube_link | json }},
-      {{ settings.social_vimeo_link | json }}
+      {{ market_social_twitter_link | json }},
+      {{ market_social_facebook_link | json }},
+      {{ market_social_pinterest_link | json }},
+      {{ market_social_instagram_link | json }},
+      {{ market_social_tiktok_link | json }},
+      {{ market_social_tumblr_link | json }},
+      {{ market_social_snapchat_link | json }},
+      {{ market_social_youtube_link | json }},
+      {{ market_social_vimeo_link | json }}
     ],
     "url": {{ request.origin | append: page.url | json }}
   }

--- a/sections/main-password-footer.liquid
+++ b/sections/main-password-footer.liquid
@@ -1,10 +1,48 @@
 {% assign scheme1 = settings.color_schemes | first %}
 {%- if section.settings.color_scheme == scheme1 -%}<hr>{%- endif -%}
 <div class="password__footer color-{{ section.settings.color_scheme }} gradient">
+{%- liquid
+  assign market_social_facebook_link = settings.social_facebook_link
+  if localization.market.handle != blank and settings.market_social_facebook_link != blank
+    assign market_social_facebook_link = settings.market_social_facebook_link
+  endif
+  assign market_social_instagram_link = settings.social_instagram_link
+  if localization.market.handle != blank and settings.market_social_instagram_link != blank
+    assign market_social_instagram_link = settings.market_social_instagram_link
+  endif
+  assign market_social_youtube_link = settings.social_youtube_link
+  if localization.market.handle != blank and settings.market_social_youtube_link != blank
+    assign market_social_youtube_link = settings.market_social_youtube_link
+  endif
+  assign market_social_tiktok_link = settings.social_tiktok_link
+  if localization.market.handle != blank and settings.market_social_tiktok_link != blank
+    assign market_social_tiktok_link = settings.market_social_tiktok_link
+  endif
+  assign market_social_twitter_link = settings.social_twitter_link
+  if localization.market.handle != blank and settings.market_social_twitter_link != blank
+    assign market_social_twitter_link = settings.market_social_twitter_link
+  endif
+  assign market_social_pinterest_link = settings.social_pinterest_link
+  if localization.market.handle != blank and settings.market_social_pinterest_link != blank
+    assign market_social_pinterest_link = settings.market_social_pinterest_link
+  endif
+  assign market_social_snapchat_link = settings.social_snapchat_link
+  if localization.market.handle != blank and settings.market_social_snapchat_link != blank
+    assign market_social_snapchat_link = settings.market_social_snapchat_link
+  endif
+  assign market_social_tumblr_link = settings.social_tumblr_link
+  if localization.market.handle != blank and settings.market_social_tumblr_link != blank
+    assign market_social_tumblr_link = settings.market_social_tumblr_link
+  endif
+  assign market_social_vimeo_link = settings.social_vimeo_link
+  if localization.market.handle != blank and settings.market_social_vimeo_link != blank
+    assign market_social_vimeo_link = settings.market_social_vimeo_link
+  endif
+-%}
   <ul class="list-social list-unstyled" role="list">
-    {%- if settings.social_twitter_link != blank -%}
+    {%- if market_social_twitter_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_twitter_link }}" class="link list-social__link">
+        <a href="{{ market_social_twitter_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-twitter.svg' | inline_asset_content -}}
           </span>
@@ -12,9 +50,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_facebook_link != blank -%}
+    {%- if market_social_facebook_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_facebook_link }}" class="link list-social__link">
+        <a href="{{ market_social_facebook_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-facebook.svg' | inline_asset_content -}}
           </span>
@@ -22,9 +60,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_pinterest_link != blank -%}
+    {%- if market_social_pinterest_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_pinterest_link }}" class="link list-social__link">
+        <a href="{{ market_social_pinterest_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-pinterest.svg' | inline_asset_content -}}
           </span>
@@ -32,9 +70,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_instagram_link != blank -%}
+    {%- if market_social_instagram_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_instagram_link }}" class="link list-social__link">
+        <a href="{{ market_social_instagram_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-instagram.svg' | inline_asset_content -}}
           </span>
@@ -42,9 +80,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_tiktok_link != blank -%}
+    {%- if market_social_tiktok_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_tiktok_link }}" class="link list-social__link">
+        <a href="{{ market_social_tiktok_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-tiktok.svg' | inline_asset_content -}}
           </span>
@@ -52,9 +90,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_tumblr_link != blank -%}
+    {%- if market_social_tumblr_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_tumblr_link }}" class="link list-social__link">
+        <a href="{{ market_social_tumblr_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-tumblr.svg' | inline_asset_content -}}
           </span>
@@ -62,9 +100,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_snapchat_link != blank -%}
+    {%- if market_social_snapchat_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_snapchat_link }}" class="link list-social__link">
+        <a href="{{ market_social_snapchat_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-snapchat.svg' | inline_asset_content -}}
           </span>
@@ -72,9 +110,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_youtube_link != blank -%}
+    {%- if market_social_youtube_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_youtube_link }}" class="link list-social__link">
+        <a href="{{ market_social_youtube_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-youtube.svg' | inline_asset_content -}}
           </span>
@@ -82,9 +120,9 @@
         </a>
       </li>
     {%- endif -%}
-    {%- if settings.social_vimeo_link != blank -%}
+    {%- if market_social_vimeo_link != blank -%}
       <li class="list-social__item">
-        <a href="{{ settings.social_vimeo_link }}" class="link list-social__link">
+        <a href="{{ market_social_vimeo_link }}" class="link list-social__link">
           <span class="svg-wrapper">
             {{- 'icon-vimeo.svg' | inline_asset_content -}}
           </span>

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -25,6 +25,45 @@
   <meta property="og:image:width" content="{{ page_image.width }}">
   <meta property="og:image:height" content="{{ page_image.height }}">
   <meta property="og:image:alt" content="{{ page_image.alt | escape }}">
+{%- liquid
+  assign market_social_facebook_link = settings.social_facebook_link
+  if localization.market.handle != blank and settings.market_social_facebook_link != blank
+    assign market_social_facebook_link = settings.market_social_facebook_link
+  endif
+  assign market_social_instagram_link = settings.social_instagram_link
+  if localization.market.handle != blank and settings.market_social_instagram_link != blank
+    assign market_social_instagram_link = settings.market_social_instagram_link
+  endif
+  assign market_social_youtube_link = settings.social_youtube_link
+  if localization.market.handle != blank and settings.market_social_youtube_link != blank
+    assign market_social_youtube_link = settings.market_social_youtube_link
+  endif
+  assign market_social_tiktok_link = settings.social_tiktok_link
+  if localization.market.handle != blank and settings.market_social_tiktok_link != blank
+    assign market_social_tiktok_link = settings.market_social_tiktok_link
+  endif
+  assign market_social_twitter_link = settings.social_twitter_link
+  if localization.market.handle != blank and settings.market_social_twitter_link != blank
+    assign market_social_twitter_link = settings.market_social_twitter_link
+  endif
+  assign market_social_pinterest_link = settings.social_pinterest_link
+  if localization.market.handle != blank and settings.market_social_pinterest_link != blank
+    assign market_social_pinterest_link = settings.market_social_pinterest_link
+  endif
+  assign market_social_snapchat_link = settings.social_snapchat_link
+  if localization.market.handle != blank and settings.market_social_snapchat_link != blank
+    assign market_social_snapchat_link = settings.market_social_snapchat_link
+  endif
+  assign market_social_tumblr_link = settings.social_tumblr_link
+  if localization.market.handle != blank and settings.market_social_tumblr_link != blank
+    assign market_social_tumblr_link = settings.market_social_tumblr_link
+  endif
+  assign market_social_vimeo_link = settings.social_vimeo_link
+  if localization.market.handle != blank and settings.market_social_vimeo_link != blank
+    assign market_social_vimeo_link = settings.market_social_vimeo_link
+  endif
+-%}
+
 {%- endif -%}
 
 {%- if request.page_type == 'product' -%}
@@ -32,8 +71,8 @@
   <meta property="og:price:currency" content="{{ cart.currency.iso_code }}">
 {%- endif -%}
 
-{%- if settings.social_twitter_link != blank -%}
-  <meta name="twitter:site" content="{{ settings.social_twitter_link | split: 'twitter.com/' | last | prepend: '@' }}">
+{%- if market_social_twitter_link != blank -%}
+  <meta name="twitter:site" content="{{ market_social_twitter_link | split: 'twitter.com/' | last | prepend: '@' }}">
 {%- endif -%}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ og_title | escape }}">

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -11,6 +11,11 @@
   elsif request.page_type == 'password'
     assign og_url = request.origin
   endif
+
+  assign market_social_twitter_link = settings.social_twitter_link
+  if localization.market.handle != blank and settings.market_social_twitter_link != blank
+    assign market_social_twitter_link = settings.market_social_twitter_link
+  endif
 %}
 
 <meta property="og:site_name" content="{{ shop.name }}">

--- a/snippets/social-icons.liquid
+++ b/snippets/social-icons.liquid
@@ -9,10 +9,49 @@
   %}
 {% endcomment %}
 
+{%- liquid
+  assign market_social_facebook_link = settings.social_facebook_link
+  if localization.market.handle != blank and settings.market_social_facebook_link != blank
+    assign market_social_facebook_link = settings.market_social_facebook_link
+  endif
+  assign market_social_instagram_link = settings.social_instagram_link
+  if localization.market.handle != blank and settings.market_social_instagram_link != blank
+    assign market_social_instagram_link = settings.market_social_instagram_link
+  endif
+  assign market_social_youtube_link = settings.social_youtube_link
+  if localization.market.handle != blank and settings.market_social_youtube_link != blank
+    assign market_social_youtube_link = settings.market_social_youtube_link
+  endif
+  assign market_social_tiktok_link = settings.social_tiktok_link
+  if localization.market.handle != blank and settings.market_social_tiktok_link != blank
+    assign market_social_tiktok_link = settings.market_social_tiktok_link
+  endif
+  assign market_social_twitter_link = settings.social_twitter_link
+  if localization.market.handle != blank and settings.market_social_twitter_link != blank
+    assign market_social_twitter_link = settings.market_social_twitter_link
+  endif
+  assign market_social_pinterest_link = settings.social_pinterest_link
+  if localization.market.handle != blank and settings.market_social_pinterest_link != blank
+    assign market_social_pinterest_link = settings.market_social_pinterest_link
+  endif
+  assign market_social_snapchat_link = settings.social_snapchat_link
+  if localization.market.handle != blank and settings.market_social_snapchat_link != blank
+    assign market_social_snapchat_link = settings.market_social_snapchat_link
+  endif
+  assign market_social_tumblr_link = settings.social_tumblr_link
+  if localization.market.handle != blank and settings.market_social_tumblr_link != blank
+    assign market_social_tumblr_link = settings.market_social_tumblr_link
+  endif
+  assign market_social_vimeo_link = settings.social_vimeo_link
+  if localization.market.handle != blank and settings.market_social_vimeo_link != blank
+    assign market_social_vimeo_link = settings.market_social_vimeo_link
+  endif
+-%}
+
 <ul class="list-unstyled list-social{% if class %} {{ class}}{% endif %} gap-4 mt-6" role="list">
-  {%- if settings.social_instagram_link != blank -%}
+  {%- if market_social_instagram_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_instagram_link }}" class="link list-social__link">
+      <a href="{{ market_social_instagram_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-instagram.svg' | inline_asset_content -}}
         </span>
@@ -20,9 +59,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_facebook_link != blank -%}
+  {%- if market_social_facebook_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_facebook_link }}" class="link list-social__link">
+      <a href="{{ market_social_facebook_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-facebook.svg' | inline_asset_content -}}
         </span>
@@ -30,9 +69,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_youtube_link != blank -%}
+  {%- if market_social_youtube_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_youtube_link }}" class="link list-social__link">
+      <a href="{{ market_social_youtube_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-youtube.svg' | inline_asset_content -}}
         </span>
@@ -40,9 +79,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_tiktok_link != blank -%}
+  {%- if market_social_tiktok_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_tiktok_link }}" class="link list-social__link">
+      <a href="{{ market_social_tiktok_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-tiktok.svg' | inline_asset_content -}}
         </span>
@@ -50,9 +89,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_twitter_link != blank -%}
+  {%- if market_social_twitter_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_twitter_link }}" class="link list-social__link">
+      <a href="{{ market_social_twitter_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-twitter.svg' | inline_asset_content -}}
         </span>
@@ -60,9 +99,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_pinterest_link != blank -%}
+  {%- if market_social_pinterest_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_pinterest_link }}" class="link list-social__link">
+      <a href="{{ market_social_pinterest_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-pinterest.svg' | inline_asset_content -}}
         </span>
@@ -70,9 +109,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_snapchat_link != blank -%}
+  {%- if market_social_snapchat_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_snapchat_link }}" class="link list-social__link">
+      <a href="{{ market_social_snapchat_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-snapchat.svg' | inline_asset_content -}}
         </span>
@@ -80,9 +119,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_tumblr_link != blank -%}
+  {%- if market_social_tumblr_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_tumblr_link }}" class="link list-social__link">
+      <a href="{{ market_social_tumblr_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-tumblr.svg' | inline_asset_content -}}
         </span>
@@ -90,9 +129,9 @@
       </a>
     </li>
   {%- endif -%}
-  {%- if settings.social_vimeo_link != blank -%}
+  {%- if market_social_vimeo_link != blank -%}
     <li class="list-social__item">
-      <a href="{{ settings.social_vimeo_link }}" class="link list-social__link">
+      <a href="{{ market_social_vimeo_link }}" class="link list-social__link">
         <span class="svg-wrapper size-6">
           {{- 'icon-vimeo.svg' | inline_asset_content -}}
         </span>

--- a/snippets/structured-data.liquid
+++ b/snippets/structured-data.liquid
@@ -6,6 +6,42 @@
 {%- liquid
   assign current_variant = product.selected_or_first_available_variant
   assign featured_image = current_variant.featured_image | default: product.featured_image
+  assign market_social_facebook_link = settings.social_facebook_link
+  if localization.market.handle != blank and settings.market_social_facebook_link != blank
+    assign market_social_facebook_link = settings.market_social_facebook_link
+  endif
+  assign market_social_instagram_link = settings.social_instagram_link
+  if localization.market.handle != blank and settings.market_social_instagram_link != blank
+    assign market_social_instagram_link = settings.market_social_instagram_link
+  endif
+  assign market_social_youtube_link = settings.social_youtube_link
+  if localization.market.handle != blank and settings.market_social_youtube_link != blank
+    assign market_social_youtube_link = settings.market_social_youtube_link
+  endif
+  assign market_social_tiktok_link = settings.social_tiktok_link
+  if localization.market.handle != blank and settings.market_social_tiktok_link != blank
+    assign market_social_tiktok_link = settings.market_social_tiktok_link
+  endif
+  assign market_social_twitter_link = settings.social_twitter_link
+  if localization.market.handle != blank and settings.market_social_twitter_link != blank
+    assign market_social_twitter_link = settings.market_social_twitter_link
+  endif
+  assign market_social_pinterest_link = settings.social_pinterest_link
+  if localization.market.handle != blank and settings.market_social_pinterest_link != blank
+    assign market_social_pinterest_link = settings.market_social_pinterest_link
+  endif
+  assign market_social_snapchat_link = settings.social_snapchat_link
+  if localization.market.handle != blank and settings.market_social_snapchat_link != blank
+    assign market_social_snapchat_link = settings.market_social_snapchat_link
+  endif
+  assign market_social_tumblr_link = settings.social_tumblr_link
+  if localization.market.handle != blank and settings.market_social_tumblr_link != blank
+    assign market_social_tumblr_link = settings.market_social_tumblr_link
+  endif
+  assign market_social_vimeo_link = settings.social_vimeo_link
+  if localization.market.handle != blank and settings.market_social_vimeo_link != blank
+    assign market_social_vimeo_link = settings.market_social_vimeo_link
+  endif
 -%}
 
 <script type="application/ld+json">
@@ -42,16 +78,16 @@
           },
         {%- endif -%}
         "sameAs": [
-          {%- if settings.social_facebook_link != blank -%}
-            {{ settings.social_facebook_link | json }}
-            {%- unless settings.social_instagram_link == blank and settings.social_twitter_link == blank -%},{%- endunless -%}
+          {%- if market_social_facebook_link != blank -%}
+            {{ market_social_facebook_link | json }}
+            {%- unless market_social_instagram_link == blank and market_social_twitter_link == blank -%},{%- endunless -%}
           {%- endif -%}
-          {%- if settings.social_instagram_link != blank -%}
-            {{ settings.social_instagram_link | json }}
-            {%- unless settings.social_twitter_link == blank -%},{%- endunless -%}
+          {%- if market_social_instagram_link != blank -%}
+            {{ market_social_instagram_link | json }}
+            {%- unless market_social_twitter_link == blank -%},{%- endunless -%}
           {%- endif -%}
-          {%- if settings.social_twitter_link != blank -%}
-            {{ settings.social_twitter_link | json }}
+          {%- if market_social_twitter_link != blank -%}
+            {{ market_social_twitter_link | json }}
           {%- endif -%}
         ]
       }


### PR DESCRIPTION
## Summary
Fixes #36.

Added optional market-specific social-link overrides for Instagram, Facebook, YouTube, TikTok, X/Twitter, Pinterest, Snapchat, Tumblr, and Vimeo.

Behavior:
- The active `localization.market.handle` is respected by the shared social rendering paths.
- A non-blank market override replaces the global social link.
- A blank market override falls back to the existing global setting.
- Footer/header visibility, password footer, metadata, social icons, and organization structured data use the same resolved values.
- Accessible translated social labels remain unchanged.

No local profile URLs were invented. Merchants must populate approved URLs in the new market override fields; blanks intentionally preserve the existing global profile.

## Verification
- Schema and all market context JSON files parsed successfully.
- `git diff --check` passed.
- Uploaded full theme files to unpublished drafts `QA issue 36 before` (ID `203080958284`) and `QA issue 36 after` (ID `203081056588`).
- The fixed preview rendered successfully, but the homepage capture did not expose the footer social block in the visible viewport. Source/render contract verification confirms the new override and fallback behavior; no misleading before/after screenshot is claimed.
- Shopify Theme Check reports the repository's pre-existing baseline errors, including missing legacy section references.

Temporary QA themes were deleted after verification.

### Locale-specific evidence
The replacement evidence comment uses the German storefront route `https://shop.northfinder.com/de` and captures the footer/social surface. No approved local social profile URLs were available, so the screenshot intentionally does not claim a URL change; the source-level contract verifies per-market override fields with global fallback when blank.
