### PR TITLE
fix(layout): prevent localized text overflow

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -513,12 +513,15 @@ p {
 
 .link-with-icon {
   display: inline-flex;
+  align-items: center;
+  max-width: 100%;
   font-size: 0.875rem;
   font-weight: 600;
   letter-spacing: 0.0625rem;
   text-decoration: none;
   margin-bottom: 4.5rem;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .link-with-icon .icon {

--- a/assets/component-accordion.css
+++ b/assets/component-accordion.css
@@ -29,7 +29,9 @@
 
 .accordion__title {
   display: inline-block;
-  max-width: calc(100% - 6rem);
+  flex: 1;
+  min-width: 0;
+  max-width: none;
   min-height: 1.6rem;
   margin: 0;
   word-break: break-word;
@@ -39,6 +41,7 @@
 }
 
 .accordion .svg-wrapper {
+  flex: 0 0 auto;
   align-self: center;
   fill: rgb(var(--color-base-foreground));
   height: calc(var(--font-heading-scale) * 2rem);

--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -77,7 +77,10 @@ cart-drawer:not(.is-empty) .cart-drawer__collection {
 }
 
 .drawer__heading {
+  flex: 1;
+  min-width: 0;
   margin: 0 0 1rem;
+  overflow-wrap: anywhere;
 }
 
 .drawer__close {
@@ -261,14 +264,18 @@ cart-drawer-items {
 
 .cart-drawer .cart-item__details {
   width: auto;
+  min-width: 0;
   grid-column: 2 / 4;
+  overflow-wrap: anywhere;
 }
 
 .cart-drawer .cart-item__totals {
   pointer-events: none;
+  min-width: 0;
   display: flex;
   align-items: flex-start;
   justify-content: flex-end;
+  overflow-wrap: anywhere;
 }
 
 .cart-drawer.cart-drawer .cart-item__price-wrapper > *:only-child {

--- a/assets/component-localization-form.css
+++ b/assets/component-localization-form.css
@@ -396,19 +396,21 @@
 
 .js .header-localization:not(.menu-drawer__localization) .localization-form__select {
   padding: 0 2.7rem 0 1.2rem;
-  width: max-content;
-  height: 3.8rem;
+  width: auto;
+  max-width: min(26ch, calc(100vw - 2rem));
+  min-height: 3.8rem;
+  height: auto;
 }
 
 .header-localization:not(.menu-drawer__localization) .localization-form:only-child .localization-form__select {
   margin: 0;
 }
 
-.header-localization:not(.menu-drawer__localization).localization-form__select > span {
-  max-width: 20ch;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+.header-localization:not(.menu-drawer__localization) .localization-form__select > span {
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .header-localization:not(.menu-drawer__localization) localization-form:only-child .localization-form__select > span {

--- a/assets/faq-tabbed-section.css
+++ b/assets/faq-tabbed-section.css
@@ -12,6 +12,21 @@
 .faq-tabbed-section__container {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+}
+
+.faq-tabbed-section__content,
+.faq-category-content,
+.faq-category-content .accordion,
+.faq-category-content .accordion summary {
+  min-width: 0;
+}
+
+.faq-tab-button,
+.faq-category-content .accordion__title,
+.faq-mobile-category-title,
+.faq-contact-block__button {
+  overflow-wrap: anywhere;
 }
 
 /* Mobile-first: Stacked layout */
@@ -76,6 +91,8 @@ details[open] .accordion__title {
 }
 
 .faq-category-content .accordion summary {
+  align-items: flex-start;
+  gap: 1rem;
   padding: 1rem 2rem;
 }
 
@@ -204,6 +221,7 @@ details[open] .accordion__title {
     color: #000;
   }
   .faq-category-content .accordion summary {
+    gap: 0.75rem;
     padding: 1rem;
   }
 

--- a/assets/section-contact-form.css
+++ b/assets/section-contact-form.css
@@ -13,6 +13,8 @@
 }
 
 .contact__form-heading {
+  max-width: 100%;
+  overflow-wrap: anywhere;
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.143;
@@ -58,6 +60,9 @@
 }
 
 .contact__button .button {
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
   background-color: #000000;
   color: #ffffff;
   border: none;

--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -90,14 +90,14 @@
     position-try-fallbacks: none !important;
   }
 
-  /* Carousel container: keep the bar at a fixed 30px height even with the slider. */
+  /* Keep the utility bar compact while allowing localized copy to wrap. */
   .announcement-bar-section .announcement-bar {
     width: 100%;
     min-width: 0;
-    height: 1.875rem;
+    min-height: 1.875rem;
+    height: auto;
     display: flex;
     align-items: center;
-    overflow: hidden;
   }
   .announcement-bar-section .announcement-bar-slider {
     width: 100%;
@@ -113,7 +113,8 @@
     margin: 0;
     display: flex;
     flex-direction: row;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
     scrollbar-width: none;
   }
   .announcement-bar-section .ab-slider::-webkit-scrollbar {
@@ -131,13 +132,12 @@
     padding: 0;
     text-align: center;
     font-size: inherit;
-    line-height: 1.875rem;
+    line-height: 1.25;
     letter-spacing: 0;
-    min-height: 0;
-    /* Keep one line; never push the bar taller. */
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    min-height: 1.875rem;
+    display: flex;
+    align-items: center;
+    overflow-wrap: anywhere;
   }
   @media screen and (min-width: 990px) {
     .announcement-bar-section .announcement-bar__message {
@@ -198,7 +198,7 @@
 
 <div class="bg-[#F5F5F5] text-[0.8125rem] leading-[0.875rem] text-secondary-foreground relative z-30">
   <div class="page-width">
-    <nav class="w-full flex flex-row justify-center lg:justify-between h-[1.875rem] items-center gap-4">
+    <nav class="w-full flex min-h-[1.875rem] flex-row justify-center lg:justify-between items-center gap-4">
       <div class="italic flex items-center justify-center lg:justify-start overflow-hidden lg:overflow-visible" style="min-width: 0; flex: 1 1 0; max-width: 100%;">
         {%- if section.blocks.size == 0 -%}
           {%- if section.settings.announcement_text != blank -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -146,7 +146,7 @@
       assign social_links = true
     endif
   -%}
-  <header class="header header--dropdown py-0 h-[3.125rem] lg:h-[3.25rem] page-width{% if section.settings.menu != blank %} header--has-menu{% endif %}{% if has_app_block %} header--has-app{% endif %}{% if social_links %} header--has-social{% endif %}{% if shop.customer_accounts_enabled %} header--has-account{% endif %}">
+  <header class="header header--dropdown py-0 min-h-[3.125rem] lg:min-h-[3.25rem] page-width{% if section.settings.menu != blank %} header--has-menu{% endif %}{% if has_app_block %} header--has-app{% endif %}{% if social_links %} header--has-social{% endif %}{% if shop.customer_accounts_enabled %} header--has-account{% endif %}">
     {%- liquid
       if section.settings.menu != blank
         render 'header-drawer'


### PR DESCRIPTION
## Summary
Fixes #35.

Localized content can now expand and wrap instead of being clipped by fixed-height or nowrap rules.

Updated shared surfaces:
- Announcement and utility bars
- Header navigation and localization controls
- Cart drawer headings, item details, totals, and metadata
- FAQ category tabs, accordion titles, mobile headings, and contact CTA
- Contact form heading and submit button
- Shared link-with-icon component

## Verification
- `git diff --check` passed.
- Before/after theme previews were uploaded with full files:
  - `QA issue 35 before` (ID `203081810252`)
  - `QA issue 35 after` (ID `203081843020`)
- Browser screenshots were captured from both unpublished previews.
- The repository test command could not run in the isolated worktree because `vitest` is unavailable.
- Shopify Theme Check reports the repository baseline errors, including missing legacy section references.

## UI before / after
The fixed CSS replaces hard clipping and fixed dimensions with responsive min-height, `min-width: 0`, wrapping, and preserved non-shrinking icons. This keeps long German/Czech/Romanian/Bulgarian/Slovenian/Slovak labels readable and prevents overlap.

Temporary QA themes were deleted after verification.

### Locale-specific evidence
The replacement evidence comment uses the German storefront route `https://shop.northfinder.com/de` at a desktop viewport, matching the desktop navigation layout shown in issue #35. Before is the `stack/market-issues-36` parent revision and after is the `stack/market-issues-35` PR revision. The desktop screenshot is the primary evidence; mobile coverage was also checked separately for the acceptance matrix.
