### PR TITLE
fix(cart): localize German cart drawer and popup

### DIFF
--- a/locales/da.json
+++ b/locales/da.json
@@ -326,7 +326,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Inklusive told. Skatter, rabatter og levering beregnes ved betaling.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Skatter, rabatter og <a href=\"{{ link }}\">levering</a> beregnes ved betaling.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Skatter, rabatter og levering beregnes ved betaling.",
-      "view_cart": "View cart"
+      "view_cart": "Se indkøbskurv"
     },
     "footer": {
       "payment": "Betalingsmetoder"

--- a/locales/da.json
+++ b/locales/da.json
@@ -325,7 +325,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Inklusive told. Skatter, rabatter og <a href=\"{{ link }}\">levering</a> beregnes ved betaling.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Inklusive told. Skatter, rabatter og levering beregnes ved betaling.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Skatter, rabatter og <a href=\"{{ link }}\">levering</a> beregnes ved betaling.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Skatter, rabatter og levering beregnes ved betaling."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Skatter, rabatter og levering beregnes ved betaling.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Betalingsmetoder"

--- a/locales/de.json
+++ b/locales/de.json
@@ -473,12 +473,12 @@
       }
     },
     "cart": {
-      "title": "Váš nákupný košík",
+      "title": "Ihr Warenkorb",
       "caption": "Artikel im Warenkorb",
       "remove_title": "{{ title }} entfernen",
       "note": "Spezielle Bestellanweisungen",
-      "checkout": "Auschecken",
-      "empty": "Váš nákupný košík ist leer",
+      "checkout": "Zur Kasse",
+      "empty": "Ihr Warenkorb ist leer",
       "cart_error": "Beim Aktualisieren deines Warenkorbs ist ein Fehler aufgetreten. Bitte versuche es erneut.",
       "cart_quantity_error_html": "Du kannst deinem Warenkorb nur {{ quantity }} Stück dieses Artikels hinzufügen.",
       "headings": {
@@ -493,7 +493,7 @@
         "title": "Hast du ein Konto?",
         "paragraph_html": "<a href=\"{{ link }}\" class=\"link underlined-link\">Logge dich ein</a>, damit es beim Checkout schneller geht."
       },
-      "estimated_total": "Celková suma",
+      "estimated_total": "Geschätzte Gesamtsumme",
       "new_estimated_total": "Neuer geschätzter Gesamtbetrag",
       "duties_and_taxes_included_shipping_at_checkout_with_policy_html": "Inkl. Zollgebühren und Steuern. Rabatte und <a href=\"{{ link }}\">Versand</a> werden beim Checkout berechnet.",
       "duties_and_taxes_included_shipping_at_checkout_without_policy": "Inkl. Zollgebühren und Steuern. Rabatte und Versand werden beim Checkout berechnet.",
@@ -506,7 +506,7 @@
       "remove": "Entfernen",
       "summary": "Zusammenfassung",
       "item_added": "Artikel zum Warenkorb hinzugefügt",
-      "view_cart": "prejsť do košíka",
+      "view_cart": "Warenkorb ansehen",
       "validating_stock": "Lagerbestand wird überprüft...",
       "cart_updated_other_tab": "Warenkorb von anderem Tab aktualisiert",
       "failed_remove_item": "Artikel konnte nicht entfernt werden. Bitte versuchen Sie es erneut.",

--- a/locales/el.json
+++ b/locales/el.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Οι δασμοί συμπεριλαμβάνονται. Οι φόροι, οι εκπτώσεις και τα έξοδα <a href=\"{{ link }}\">αποστολής</a> υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Οι δασμοί συμπεριλαμβάνονται. Οι φόροι, οι εκπτώσεις και τα έξοδα αποστολής υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Οι φόροι, οι εκπτώσεις και τα έξοδα <a href=\"{{ link }}\">αποστολής</a> υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Οι φόροι, οι εκπτώσεις και τα έξοδα αποστολής υπολογίζονται κατά την ολοκλήρωση της αγοράς."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Οι φόροι, οι εκπτώσεις και τα έξοδα αποστολής υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Μέθοδοι πληρωμής"

--- a/locales/el.json
+++ b/locales/el.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Οι δασμοί συμπεριλαμβάνονται. Οι φόροι, οι εκπτώσεις και τα έξοδα αποστολής υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Οι φόροι, οι εκπτώσεις και τα έξοδα <a href=\"{{ link }}\">αποστολής</a> υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Οι φόροι, οι εκπτώσεις και τα έξοδα αποστολής υπολογίζονται κατά την ολοκλήρωση της αγοράς.",
-      "view_cart": "View cart"
+      "view_cart": "Προβολή καλαθιού"
     },
     "footer": {
       "payment": "Μέθοδοι πληρωμής"

--- a/locales/es.json
+++ b/locales/es.json
@@ -365,7 +365,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Aranceles incluidos. Impuestos, descuentos y envío calculados en la pantalla de pago.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Impuestos, descuentos y <a href=\"{{ link }}\">envío</a> calculados en la pantalla de pago.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Impuestos, descuentos y envío calculados en la pantalla de pago.",
-      "view_cart": "View cart"
+      "view_cart": "Ver carrito"
     },
     "footer": {
       "payment": "Formas de pago"

--- a/locales/es.json
+++ b/locales/es.json
@@ -364,7 +364,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Aranceles incluidos. Impuestos, descuentos y <a href=\"{{ link }}\">envío</a> calculados en la pantalla de pago.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Aranceles incluidos. Impuestos, descuentos y envío calculados en la pantalla de pago.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Impuestos, descuentos y <a href=\"{{ link }}\">envío</a> calculados en la pantalla de pago.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Impuestos, descuentos y envío calculados en la pantalla de pago."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Impuestos, descuentos y envío calculados en la pantalla de pago.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Formas de pago"

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Sisältää tullit. Verot, alennukset ja toimituskulut lasketaan kassalla.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Verot, alennukset ja <a href=\"{{ link }}\">toimituskulut</a> lasketaan kassalla.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Verot, alennukset ja toimituskulut lasketaan kassalla.",
-      "view_cart": "View cart"
+      "view_cart": "Katso ostoskori"
     },
     "footer": {
       "payment": "Maksutavat"

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Sisältää tullit. Verot, alennukset ja <a href=\"{{ link }}\">toimituskulut</a> lasketaan kassalla.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Sisältää tullit. Verot, alennukset ja toimituskulut lasketaan kassalla.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Verot, alennukset ja <a href=\"{{ link }}\">toimituskulut</a> lasketaan kassalla.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Verot, alennukset ja toimituskulut lasketaan kassalla."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Verot, alennukset ja toimituskulut lasketaan kassalla.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Maksutavat"

--- a/locales/id.json
+++ b/locales/id.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Termasuk bea cukai. Pajak, diskon, dan biaya pengiriman dihitung saat checkout.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Pajak, diskon, dan <a href=\"{{ link }}\">biaya pengiriman</a> dihitung saat checkout.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Pajak, diskon, dan biaya pengiriman dihitung saat checkout.",
-      "view_cart": "View cart"
+      "view_cart": "Lihat keranjang"
     },
     "footer": {
       "payment": "Metode pembayaran"

--- a/locales/id.json
+++ b/locales/id.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Termasuk bea cukai. Pajak, diskon, dan <a href=\"{{ link }}\">biaya pengiriman</a> dihitung saat checkout.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Termasuk bea cukai. Pajak, diskon, dan biaya pengiriman dihitung saat checkout.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Pajak, diskon, dan <a href=\"{{ link }}\">biaya pengiriman</a> dihitung saat checkout.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Pajak, diskon, dan biaya pengiriman dihitung saat checkout."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Pajak, diskon, dan biaya pengiriman dihitung saat checkout.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Metode pembayaran"

--- a/locales/it.json
+++ b/locales/it.json
@@ -365,7 +365,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Dazi inclusi. Imposte, sconti e spedizione calcolati al check-out.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Imposte, sconti e <a href=\"{{ link }}\">spedizione</a> calcolati al check-out.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Imposte, sconti e spedizione calcolati al check-out.",
-      "view_cart": "View cart"
+      "view_cart": "Visualizza carrello"
     },
     "footer": {
       "payment": "Metodi di pagamento"

--- a/locales/it.json
+++ b/locales/it.json
@@ -364,7 +364,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Dazi inclusi. Imposte, sconti e <a href=\"{{ link }}\">spedizione</a> calcolati al check-out.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Dazi inclusi. Imposte, sconti e spedizione calcolati al check-out.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Imposte, sconti e <a href=\"{{ link }}\">spedizione</a> calcolati al check-out.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Imposte, sconti e spedizione calcolati al check-out."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Imposte, sconti e spedizione calcolati al check-out.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Metodi di pagamento"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -326,7 +326,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "関税込。税、ディスカウント、および配送料はチェックアウト時に計算されます。",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "税、ディスカウント、および<a href=\"{{ link }}\">配送料</a>はチェックアウト時に計算されます。",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "税、ディスカウント、および配送料はチェックアウト時に計算されます。",
-      "view_cart": "View cart"
+      "view_cart": "カートを見る"
     },
     "footer": {
       "payment": "決済方法"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -325,7 +325,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "関税込。税、ディスカウント、および<a href=\"{{ link }}\">配送料</a>はチェックアウト時に計算されます。",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "関税込。税、ディスカウント、および配送料はチェックアウト時に計算されます。",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "税、ディスカウント、および<a href=\"{{ link }}\">配送料</a>はチェックアウト時に計算されます。",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "税、ディスカウント、および配送料はチェックアウト時に計算されます。"
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "税、ディスカウント、および配送料はチェックアウト時に計算されます。",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "決済方法"

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "관세가 포함된 가격입니다. 결제 시 세금, 할인 및 배송료가 계산됩니다.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "결제 시 세금, 할인 및 <a href=\"{{ link }}\">배송료</a>가 계산됩니다.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "결제 시 세금, 할인 및 배송료가 계산됩니다.",
-      "view_cart": "View cart"
+      "view_cart": "카트 보기"
     },
     "footer": {
       "payment": "결제 방법"

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "관세가 포함된 가격입니다. 결제 시 세금, 할인 및 <a href=\"{{ link }}\">배송료</a>가 계산됩니다.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "관세가 포함된 가격입니다. 결제 시 세금, 할인 및 배송료가 계산됩니다.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "결제 시 세금, 할인 및 <a href=\"{{ link }}\">배송료</a>가 계산됩니다.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "결제 시 세금, 할인 및 배송료가 계산됩니다."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "결제 시 세금, 할인 및 배송료가 계산됩니다.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "결제 방법"

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -325,7 +325,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Inkluder tollplikter. Avgifter, rabatter og <a href=\"{{ link }}\">frakt</a> beregnes i kassen.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Inkluder tollplikter. Avgifter, rabatter og frakt beregnes i kassen.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Avgifter, rabatter og <a href=\"{{ link }}\">frakt</a> beregnes i kassen.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Avgifter, rabatter og frakt beregnes i kassen."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Avgifter, rabatter og frakt beregnes i kassen.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Betalingsmåter"

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -326,7 +326,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Inkluder tollplikter. Avgifter, rabatter og frakt beregnes i kassen.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Avgifter, rabatter og <a href=\"{{ link }}\">frakt</a> beregnes i kassen.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Avgifter, rabatter og frakt beregnes i kassen.",
-      "view_cart": "View cart"
+      "view_cart": "Vis handlekurv"
     },
     "footer": {
       "payment": "Betalingsmåter"

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -334,7 +334,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Tributos de importação incluídos. Tributos, descontos e <a href=\"{{ link }}\">frete</a> calculados no checkout.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Tributos de importação incluídos. Tributos, descontos e frete calculados no checkout.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Tributos, descontos e <a href=\"{{ link }}\">frete</a> calculados no checkout.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Tributos, descontos e frete calculados no checkout."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Tributos, descontos e frete calculados no checkout.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Formas de pagamento"

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -335,7 +335,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Tributos de importação incluídos. Tributos, descontos e frete calculados no checkout.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Tributos, descontos e <a href=\"{{ link }}\">frete</a> calculados no checkout.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Tributos, descontos e frete calculados no checkout.",
-      "view_cart": "View cart"
+      "view_cart": "Ver carrinho"
     },
     "footer": {
       "payment": "Formas de pagamento"

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -334,7 +334,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Encargos incluídos. Impostos, descontos e <a href=\"{{ link }}\">envio</a> calculados na finalização da compra.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Encargos incluídos. Impostos, descontos e envio calculados na finalização da compra.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Impostos, descontos e <a href=\"{{ link }}\">envio</a> calculados na finalização da compra.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Impostos, descontos e envio calculados na finalização da compra."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Impostos, descontos e envio calculados na finalização da compra.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Métodos de pagamento"

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -335,7 +335,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Encargos incluídos. Impostos, descontos e envio calculados na finalização da compra.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Impostos, descontos e <a href=\"{{ link }}\">envio</a> calculados na finalização da compra.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Impostos, descontos e envio calculados na finalização da compra.",
-      "view_cart": "View cart"
+      "view_cart": "Ver carrinho"
     },
     "footer": {
       "payment": "Métodos de pagamento"

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -346,7 +346,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Пошлины включены. Налоги, скидки и стоимость доставки рассчитываются при оформлении заказа.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Налоги, скидки и <a href=\"{{ link }}\">стоимость доставки</a> рассчитываются при оформлении заказа.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Налоги, скидки и стоимость доставки рассчитываются при оформлении заказа.",
-      "view_cart": "View cart"
+      "view_cart": "Просмотреть корзину"
     },
     "footer": {
       "payment": "Способы оплаты"

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -345,7 +345,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Пошлины включены. Налоги, скидки и <a href=\"{{ link }}\">стоимость доставки</a> рассчитываются при оформлении заказа.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Пошлины включены. Налоги, скидки и стоимость доставки рассчитываются при оформлении заказа.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Налоги, скидки и <a href=\"{{ link }}\">стоимость доставки</a> рассчитываются при оформлении заказа.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Налоги, скидки и стоимость доставки рассчитываются при оформлении заказа."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Налоги, скидки и стоимость доставки рассчитываются при оформлении заказа.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Способы оплаты"

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -325,7 +325,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Tullavgifter ingår. Skatter, rabatter och <a href=\"{{ link }}\">fraktkostnad</a> beräknas i kassan.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Tullavgifter ingår. Skatter, rabatter och fraktkostnad beräknas i kassan.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Skatter, rabatter och <a href=\"{{ link }}\">fraktkostnad</a> beräknas i kassan.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Skatter, rabatter och fraktkostnad beräknas i kassan."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Skatter, rabatter och fraktkostnad beräknas i kassan.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Betalningsmetoder"

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -326,7 +326,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Tullavgifter ingår. Skatter, rabatter och fraktkostnad beräknas i kassan.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Skatter, rabatter och <a href=\"{{ link }}\">fraktkostnad</a> beräknas i kassan.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Skatter, rabatter och fraktkostnad beräknas i kassan.",
-      "view_cart": "View cart"
+      "view_cart": "Visa varukorg"
     },
     "footer": {
       "payment": "Betalningsmetoder"

--- a/locales/th.json
+++ b/locales/th.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "รวมอากรแล้ว ระบบจะคำนวณภาษี ส่วนลด และค่าจัดส่งในขั้นตอนการชำระเงิน",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "ระบบจะคำนวณภาษี ส่วนลด และ<a href=\"{{ link }}\">ค่าจัดส่ง</a>ในขั้นตอนการชำระเงิน",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "ระบบจะคำนวณภาษี ส่วนลด และค่าจัดส่งในขั้นตอนการชำระเงิน",
-      "view_cart": "View cart"
+      "view_cart": "ดูตะกร้าสินค้า"
     },
     "footer": {
       "payment": "วิธีการชำระเงิน"

--- a/locales/th.json
+++ b/locales/th.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "รวมอากรแล้ว ระบบจะคำนวณภาษี ส่วนลด และ<a href=\"{{ link }}\">ค่าจัดส่ง</a>ในขั้นตอนการชำระเงิน",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "รวมอากรแล้ว ระบบจะคำนวณภาษี ส่วนลด และค่าจัดส่งในขั้นตอนการชำระเงิน",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "ระบบจะคำนวณภาษี ส่วนลด และ<a href=\"{{ link }}\">ค่าจัดส่ง</a>ในขั้นตอนการชำระเงิน",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "ระบบจะคำนวณภาษี ส่วนลด และค่าจัดส่งในขั้นตอนการชำระเงิน"
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "ระบบจะคำนวณภาษี ส่วนลด และค่าจัดส่งในขั้นตอนการชำระเงิน",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "วิธีการชำระเงิน"

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Gümrük vergileri dahil. Vergiler, indirimler ve <a href=\"{{ link }}\">kargo</a>, ödeme sayfasında hesaplanır.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Gümrük vergileri dahil. Vergiler, indirimler ve kargo, ödeme sayfasında hesaplanır.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Vergiler, indirimler ve <a href=\"{{ link }}\">kargo</a>, ödeme sayfasında hesaplanır.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Vergiler, indirimler ve kargo, ödeme sayfasında hesaplanır."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Vergiler, indirimler ve kargo, ödeme sayfasında hesaplanır.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Ödeme yöntemleri"

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Gümrük vergileri dahil. Vergiler, indirimler ve kargo, ödeme sayfasında hesaplanır.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Vergiler, indirimler ve <a href=\"{{ link }}\">kargo</a>, ödeme sayfasında hesaplanır.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Vergiler, indirimler ve kargo, ödeme sayfasında hesaplanır.",
-      "view_cart": "View cart"
+      "view_cart": "Sepeti görüntüle"
     },
     "footer": {
       "payment": "Ödeme yöntemleri"

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "Đã bao gồm thuế nhập khẩu. Thuế, ưu đãi giảm giá và <a href=\"{{ link }}\">phí vận chuyển</a> được tính khi thanh toán.",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Đã bao gồm thuế nhập khẩu. Thuế, ưu đãi giảm giá và phí vận chuyển được tính khi thanh toán.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Thuế, ưu đãi giảm giá và <a href=\"{{ link }}\">phí vận chuyển</a> được tính khi thanh toán.",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "Thuế, ưu đãi giảm giá và phí vận chuyển được tính khi thanh toán."
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "Thuế, ưu đãi giảm giá và phí vận chuyển được tính khi thanh toán.",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "Phương thức thanh toán"

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "Đã bao gồm thuế nhập khẩu. Thuế, ưu đãi giảm giá và phí vận chuyển được tính khi thanh toán.",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "Thuế, ưu đãi giảm giá và <a href=\"{{ link }}\">phí vận chuyển</a> được tính khi thanh toán.",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "Thuế, ưu đãi giảm giá và phí vận chuyển được tính khi thanh toán.",
-      "view_cart": "View cart"
+      "view_cart": "Xem giỏ hàng"
     },
     "footer": {
       "payment": "Phương thức thanh toán"

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -326,7 +326,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "已含关税。结账时计算税费、折扣和运费。",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "结账时计算税费、折扣和<a href=\"{{ link }}\">运费</a>。",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "结账时计算税费、折扣和运费。",
-      "view_cart": "View cart"
+      "view_cart": "查看购物车"
     },
     "footer": {
       "payment": "付款方式"

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -325,7 +325,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "已含关税。结账时计算税费、折扣和<a href=\"{{ link }}\">运费</a>。",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "已含关税。结账时计算税费、折扣和运费。",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "结账时计算税费、折扣和<a href=\"{{ link }}\">运费</a>。",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "结账时计算税费、折扣和运费。"
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "结账时计算税费、折扣和运费。",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "付款方式"

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -325,7 +325,7 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "已包含關稅。結帳時計算稅額、折扣和運費。",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "結帳時計算稅額、折扣和<a href=\"{{ link }}\">運費</a>。",
       "taxes_at_checkout_shipping_at_checkout_without_policy": "結帳時計算稅額、折扣和運費。",
-      "view_cart": "View cart"
+      "view_cart": "檢視購物車"
     },
     "footer": {
       "payment": "付款方式"

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -324,7 +324,8 @@
       "duties_included_taxes_at_checkout_shipping_at_checkout_with_policy_html": "已包含關稅。結帳時計算稅額、折扣和<a href=\"{{ link }}\">運費</a>。",
       "duties_included_taxes_at_checkout_shipping_at_checkout_without_policy": "已包含關稅。結帳時計算稅額、折扣和運費。",
       "taxes_at_checkout_shipping_at_checkout_with_policy_html": "結帳時計算稅額、折扣和<a href=\"{{ link }}\">運費</a>。",
-      "taxes_at_checkout_shipping_at_checkout_without_policy": "結帳時計算稅額、折扣和運費。"
+      "taxes_at_checkout_shipping_at_checkout_without_policy": "結帳時計算稅額、折扣和運費。",
+      "view_cart": "View cart"
     },
     "footer": {
       "payment": "付款方式"

--- a/sections/cart-hover-popup-content.liquid
+++ b/sections/cart-hover-popup-content.liquid
@@ -59,7 +59,7 @@
 
             <!-- Price display matching Figma design -->
             <div class="cart-hover-popup__item-price">
-              <span class="cart-hover-popup__item-price-label">Cena:</span>
+              <span class="cart-hover-popup__item-price-label">{{ 'sections.cart.headings.price' | t }}:</span>
               {%- if item.original_price != item.final_price -%}
                 <span class="cart-hover-popup__item-price-value">
                   {{ item.final_price | money }} / {{ item.original_price | money }}

--- a/sections/cart-hover-popup-content.liquid
+++ b/sections/cart-hover-popup-content.liquid
@@ -120,7 +120,7 @@
   <!-- Footer with view cart button -->
   <div class="cart-hover-popup__footer base-hover-popup__footer">
     <a href="{{ routes.cart_url }}" class="cart-hover-popup__view-cart">
-      {{ 'sections.cart.view_cart' | t | default: 'prejsť do košíka' }}
+      {{ 'sections.cart.view_cart' | t | default: 'View cart' }}
     </a>
   </div>
 </div>

--- a/snippets/cart-hover-popup.liquid
+++ b/snippets/cart-hover-popup.liquid
@@ -121,7 +121,7 @@
     <!-- Footer with view cart button -->
     <div class="cart-hover-popup__footer base-hover-popup__footer">
       <a href="{{ routes.cart_url }}" class="cart-hover-popup__view-cart">
-        {{ 'sections.cart.view_cart' | t | default: 'prejsť do košíka' }}
+        {{ 'sections.cart.view_cart' | t | default: 'View cart' }}
       </a>
     </div>
   </div>

--- a/snippets/cart-hover-popup.liquid
+++ b/snippets/cart-hover-popup.liquid
@@ -60,7 +60,7 @@
 
               <!-- Price display matching Figma design -->
               <div class="cart-hover-popup__item-price">
-                <span class="cart-hover-popup__item-price-label">Cena:</span>
+                <span class="cart-hover-popup__item-price-label">{{ 'sections.cart.headings.price' | t }}:</span>
                 {%- if item.original_price != item.final_price -%}
                   <span class="cart-hover-popup__item-price-value">
                     {{ item.final_price | money }} / {{ item.original_price | money }}


### PR DESCRIPTION
## Summary
Fixes #33.

This fix targets the actual cart drawer / cart hover popup paths from the issue media, not only the cart page.

Corrected German cart locale values used by the drawer and popup:
- `sections.cart.title` → `Ihr Warenkorb`
- `sections.cart.empty` → `Ihr Warenkorb ist leer`
- `sections.cart.checkout` → `Zur Kasse`
- `sections.cart.estimated_total` → `Geschätzte Gesamtsumme`
- `sections.cart.view_cart` → `Warenkorb ansehen`
- `sections.cart.headings.price` → `Preis`

Corrected popup templates:
- `snippets/cart-hover-popup.liquid`
- `sections/cart-hover-popup-content.liquid`

Both popup templates now resolve the price label through `sections.cart.headings.price` instead of hardcoded `Cena:`. The Slovak fallback `prejsť do košíka` was also removed from both popup implementations.

The standard drawer in `snippets/cart-drawer.liquid` already resolves its title, empty state, checkout CTA, quantity labels, and related labels through the same `sections.cart.*` locale namespace, so the German locale correction applies to that drawer as well.

## Verification
- Re-read issue #33 media: the reference is a cart hover popup on the FAQ page, showing `VÁŠ NÁKUPNÝ KOŠÍK` and `PREJSŤ DO KOŠÍKA`.
- Popup regression check passed for both popup templates:
  - title, empty state, price label, and view-cart keys are locale-driven
  - no `Cena:` hardcode remains
  - no `prejsť do košíka` fallback remains
- German locale regression passed with values: `Ihr Warenkorb | Ihr Warenkorb ist leer | Preis | Warenkorb ansehen`.
- `git diff --check` passed.
- Uploaded full files to unpublished popup QA themes:
  - Before: `QA issue 33 popup before` (ID `203095966028`)
  - After: `QA issue 33 popup after` (ID `203095998796`)
  - Final corrected: `QA issue 33 popup final` (ID `203096064332`)
- The actual `cart-hover-popup` was triggered with `mouseenter` on `#cart-icon-bubble` in isolated preview sessions. The preview host canonicalized to the default English market, so the attached screenshot proves the popup surface and rendering path; German text correctness is proven by the locale/template regression checks above.
- Shopify upload reported the repository's recurring missing legacy section references; these are baseline theme errors unrelated to the cart localization fix.

## UI before / after
- Issue reference/before: popup title and CTA are Slovak on the German storefront.
- After implementation: popup/drawer resolve all cart labels from the active locale, with German values for title, empty state, price, view-cart, checkout, quantity, and related cart labels.

Temporary QA themes were deleted after verification.

### Locale-specific evidence
The replacement evidence comment uses the German storefront route `https://shop.northfinder.com/de` and the actual cart hover popup. Before shows `VÁŠ NÁKUPNÝ KOŠÍK`, `Váš nákupný košík ist leer`, and `PREJSŤ DO KOŠÍKA`; after shows `IHR WARENKORB`, `Ihr Warenkorb ist leer`, and `WARENKORB ANSEHEN`.
