### PR TITLE
fix: align footer contact rows

### DIFF
--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -404,7 +404,11 @@
 @media screen and (min-width: 750px) {
   /* Keep contact rows aligned with the menu rows beside the brand column. */
   .footer-block__brand-info > .footer-block__image-wrapper {
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.5625rem;
+  }
+
+  .footer-block__brand-info > .flex {
+    row-gap: 0.875rem;
   }
 }
 

--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -401,6 +401,13 @@
   overflow: hidden !important;
 }
 
+@media screen and (min-width: 750px) {
+  /* Keep contact rows aligned with the menu rows beside the brand column. */
+  .footer-block__brand-info > .footer-block__image-wrapper {
+    margin-bottom: 1.5rem;
+  }
+}
+
 @media screen and (max-width: 750px) {
   .footer-block__image-wrapper {
     display: none;


### PR DESCRIPTION
## Summary
- align the desktop contact block with adjacent footer menu rows
- reduce the brand logo reserve and match contact row spacing
- keep the adjustment scoped to desktop footer styling

## Verification
- Shopify development theme: `footer-contact-row-alignment` (theme ID `203158487372`)
- Preview: https://sportfinder-international.myshopify.com/?preview_theme_id=203158487372
- Browser verification confirmed `Shopify.theme.id = 203158487372` and `role = development`
- Footer screenshot captured from the draft theme: `.tmp/evidence/footer-draft-final.png`
- `pnpm test:ci`: 18 tests passed
- `git diff --check`: passed

The footer screenshot shows phone, email, and contact rows beginning on the same visual rows as the corresponding adjacent menu links. Wrapped menu labels retain their natural additional line height.
