### PR TITLE
fix(loyalty): prevent tier label clipping

### DIFF
--- a/assets/bon-loyalty-page.css
+++ b/assets/bon-loyalty-page.css
@@ -96,3 +96,22 @@
 .bon-loyalty-page [id='profile-balance-table'] .bon-table-custom tbody td:last-child {
   color: var(--bon-loyalty-success) !important;
 }
+
+/* BON injects inline positioning and nowrap styles, so tier labels need priority to wrap safely. */
+.bon-loyalty-page .bon-table-tier .bon-progress .bon-text-vip-tier {
+  box-sizing: border-box !important;
+  inline-size: calc(100% - 8px) !important;
+  max-inline-size: calc(100% - 8px) !important;
+  inset-block-start: 50% !important;
+  inset-inline-start: 50% !important;
+  transform: translate(-50%, -50%) !important;
+  white-space: normal !important;
+  text-align: center !important;
+  line-height: 1.2 !important;
+}
+
+@media screen and (max-width: 1100px) {
+  .bon-loyalty-page .bon-table-tier .bon-progress .bon-text-vip-tier {
+    font-size: 12px !important;
+  }
+}


### PR DESCRIPTION
## Summary
- constrain BON loyalty tier labels to the progress-bar width
- allow translated threshold text to wrap and remain vertically centered
- reduce the label font size below 1100px so the desktop tier table remains readable on narrower viewports

## Cause
BON injects each label with absolute positioning and a single-line layout. The rendered Slovak labels are wider than their `.bon-progress` containers, which use `overflow: hidden`, so the text is clipped.

## Validation
- Injected the exact override into the live `/pages/vernostny-program` page in Orca and verified all three labels fit at the reported 1929px viewport
- Measured successful fit at 1929px, 1440px, 1280px, 1024px, and 768px viewports
- `vitest run`: 25 tests passed
- focused Prettier check for the added CSS block: passed
- CSS structure assertions: passed
- `git diff --check`: passed

## Theme Check
`shopify theme check --fail-level error` still reports the existing repository baseline: 305 errors and 816 warnings across legacy files. The BON template itself only reports its pre-existing remote asset warning, and this PR changes no Liquid files.
