### PR TITLE
fix(search): hide view all results link

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -490,56 +490,8 @@ predictive-search[loading] .predictive-search__results-groups-wrapper ~ .predict
   color: var(--color-black);  /* #000000 */
 }
 
-button.nf__predictive-search__view-all-button {
-  /* Use unified button system */
-  @extend .button;
-  @extend .button--primary;
-
-  /* Keep specific styling for predictive search */
-  width: 100%;
-  height: 2.25rem;
-  text-transform: uppercase;
-  font-size: 0.875rem;
-  line-height: 1rem;
-  gap: 0.5rem;
-  margin-top: auto;
-
-  /* Ensure unified button structure works */
-  position: relative;
-}
-
-/* Unified loading state for predictive search button */
-button.nf__predictive-search__view-all-button.loading {
-  background-color: var(--color-gray-900) !important;
-  display: grid;
-  place-items: center;
-}
-
-button.nf__predictive-search__view-all-button.loading .button-text {
-  visibility: hidden;
-  grid-area: 1 / 1;
-}
-
-button.nf__predictive-search__view-all-button.loading .button-spinner {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  grid-area: 1 / 1;
-  width: 20px;
-  height: 20px;
-}
-
-button.nf__predictive-search__view-all-button.loading .button-spinner svg {
-  width: 20px;
-  height: 20px;
-  animation: spin 1s linear infinite;
-}
 @media screen and (min-width: 750px) {
   .nf__predictive-search__results-groups-wrapper{
     height: auto;
-  }
-
-  button.nf__predictive-search__view-all-button {
-    margin-top: 0;
   }
 }

--- a/assets/predictive-search.js
+++ b/assets/predictive-search.js
@@ -20,7 +20,6 @@ class PredictiveSearch extends SearchForm {
       categories: this.decodeHtmlEntities(window.theme?.strings?.search?.categories || 'Categories'),
       articles: this.decodeHtmlEntities(window.theme?.strings?.search?.articles || 'Articles'),
       products: this.decodeHtmlEntities(window.theme?.strings?.search?.products || 'Products'),
-      view_all_results: this.decodeHtmlEntities(window.theme?.strings?.search?.view_all_results || 'View all results'),
       no_results: this.decodeHtmlEntities(window.theme?.strings?.search?.no_results || 'No results found for {{ terms }}. Check the spelling or use a different word or phrase.'),
       no_results_suggestion: this.decodeHtmlEntities(window.theme?.strings?.search?.no_results_suggestion || 'Try checking your spelling or using different words.')
     };
@@ -316,9 +315,6 @@ class PredictiveSearch extends SearchForm {
         };
       })
       .filter(({ items }) => items.length);
-    const resultCount = resultGroups.reduce((count, { items }) => count + items.length, 0);
-    const allResultsUrl = new URL(routes.search_url, window.location.origin);
-    allResultsUrl.searchParams.set('q', this.searchTerm);
 
     const html = template`
     <div class="nf__predictive-search-results">
@@ -425,16 +421,6 @@ class PredictiveSearch extends SearchForm {
           })
           .filter(Boolean)}
       </div>
-      ${resultCount ? hyperHTML.wire()`
-        <a
-          id="predictive-search-view-all"
-          class="nf__predictive-search__view-all-button button button--primary"
-          href="${allResultsUrl}"
-          role="option"
-          aria-selected="false"
-          tabindex="-1"
-        >${this.translations.view_all_results}</a>
-      ` : ''}
     </div>
   `;
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -526,10 +526,6 @@
     <script src="{{ 'search-form.js' | asset_url }}" defer="defer"></script>
 
     {%- if settings.predictive_search_enabled -%}
-      {%- assign search_view_all_results = 'templates.search.view_all_results' | t -%}
-      {%- if search_view_all_results contains 'Translation missing' -%}
-        {%- assign search_view_all_results = 'View all results' -%}
-      {%- endif -%}
       <script>
         window.theme = window.theme || {};
         window.theme.strings = window.theme.strings || {};
@@ -537,7 +533,6 @@
           categories: `{{ 'templates.search.categories' | t | escape }}`,
           articles: `{{ 'templates.search.articles' | t | escape }}`,
           products: `{{ 'templates.search.products' | t | escape }}`,
-          view_all_results: `{{ search_view_all_results | escape }}`,
           no_results: `{{ 'templates.search.no_results' | t | escape }}`,
           no_results_suggestion: `{{ 'templates.search.no_results_suggestion' | t | escape }}`
         };

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -1544,7 +1544,6 @@
       "page": "Page",
       "pages": "Pages",
       "products": "Products",
-      "view_all_results": "View all results",
       "results_pages_with_count": {
         "one": "{{ count }} page",
         "other": "{{ count }} pages"


### PR DESCRIPTION
## Summary

- remove the “View all results” link from predictive search results
- remove its unused URL/count and translation wiring
- remove obsolete button-specific CSS

## Validation

- Shopify theme validation passed for all four modified files
- `node --check assets/predictive-search.js`
- locale JSON parse check
- `git diff --check`
- verified on an unpublished Shopify theme preview with populated predictive results

## Draft theme

- Theme: `QA Hide Search View All 2026-08-05`
- Theme ID: `203176378700`
- Preview: https://shop.northfinder.com/?preview_theme_id=203176378700

## Notes

The full draft upload reported existing unrelated EComposer template references to missing section files. The draft was still created and the predictive search flow was verified on the unpublished theme.
