### PR TITLE
fix(contact): restore locale translation data

### DIFF
--- a/config/settings_data.context.bulgaria.json
+++ b/config/settings_data.context.bulgaria.json
@@ -12,7 +12,6 @@
     "market": "bulgaria"
   },
   "current": {
-    "market_contact_email": "eshop@northfinder.bg",
     "market_social_facebook_link": "",
     "market_social_instagram_link": "",
     "market_social_youtube_link": "",

--- a/config/settings_data.context.croatia.json
+++ b/config/settings_data.context.croatia.json
@@ -12,7 +12,6 @@
     "market": "croatia"
   },
   "current": {
-    "market_contact_email": "eshop@northfinder.hr",
     "market_social_facebook_link": "",
     "market_social_instagram_link": "",
     "market_social_youtube_link": "",

--- a/config/settings_data.context.slovenia.json
+++ b/config/settings_data.context.slovenia.json
@@ -12,8 +12,6 @@
     "market": "slovenia"
   },
   "current": {
-    "market_contact_email": "eshop@northfinder.com",
-    "market_contact_address": "Rastislavova 109, Lužianky 951 41, Slovakia",
     "market_social_facebook_link": "",
     "market_social_instagram_link": "",
     "market_social_youtube_link": "",

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -130,8 +130,6 @@
     "show_cart_note": false,
     "cart_drawer_collection": "",
     "cart_color_scheme": "scheme-1",
-    "contact_email": "eshop@northfinder.com",
-    "contact_phone": "+421 2 33 418 364",
     "contact_page_url": "shopify://pages/contact",
     "seo_noindex_enabled": false,
     "sections": {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1567,83 +1567,12 @@
     ]
   },
   {
-    "name": "Global Contact Info",
+    "name": "Contact",
     "settings": [
-      {
-        "type": "text",
-        "id": "contact_email",
-        "label": "Contact Email",
-        "default": "eshop@northfinder.sk"
-      },
-      {
-        "type": "text",
-        "id": "contact_phone",
-        "label": "Contact Phone",
-        "default": "+421 233 418 364"
-      },
-      {
-        "type": "text",
-        "id": "contact_address",
-        "label": "Contact Address",
-        "default": "Rastislavova 109, 951 41 Lužianky, Slovakia"
-      },
-      {
-        "type": "text",
-        "id": "contact_hours",
-        "label": "Contact Hours",
-        "default": "Monday - Friday 8:00 – 16:00"
-      },
       {
         "type": "url",
         "id": "contact_page_url",
         "label": "Contact Page URL"
-      },
-      {
-        "type": "header",
-        "content": "Market Contact Overrides",
-        "info": "Optional market-specific values. Leave blank to use the global contact information."
-      },
-      {
-        "type": "text",
-        "id": "market_contact_email",
-        "label": "Market Contact Email",
-        "info": "Optional email shown for the active market"
-      },
-      {
-        "type": "text",
-        "id": "market_contact_phone",
-        "label": "Market Contact Phone",
-        "info": "Optional phone shown for the active market"
-      },
-      {
-        "type": "text",
-        "id": "market_contact_address",
-        "label": "Market Contact Address",
-        "info": "Optional address shown for the active market"
-      },
-      {
-        "type": "text",
-        "id": "market_contact_hours",
-        "label": "Market Contact Hours",
-        "info": "Optional opening hours shown for the active market"
-      },
-      {
-        "type": "text",
-        "id": "market_contact_person_email",
-        "label": "Market Partnership Contact Email",
-        "info": "Optional partnership contact email"
-      },
-      {
-        "type": "text",
-        "id": "market_contact_person_name",
-        "label": "Market Partnership Contact Name",
-        "info": "Optional partnership contact name"
-      },
-      {
-        "type": "text",
-        "id": "market_contact_person_phone",
-        "label": "Market Partnership Contact Phone",
-        "info": "Optional partnership contact phone"
       }
     ]
   },

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -1629,7 +1629,7 @@
         "write_to_us": "Пишете ни"
       },
       "info": {
-        "address": "Rastislavova 109, 951 41 Lužianky, Словакия",
+        "address": "Str. Vasil Radoslav 6, 1715 Sofia, Bulgaria",
         "email": "eshop@northfinder.bg",
         "hours": "Понеделник - Петък 8:00 – 16:00",
         "phone": "+35 94 2952 904",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -450,10 +450,10 @@
         "write_to_us": "Napište nám"
       },
       "info": {
-        "address": "Rastislavova 109, 951 41 Lužianky, Slovakia",
-        "email": "eshop@northfinder.com",
+        "address": "Kaštanová 489/34, 620 00 Brno – Brněnské Ivanovice",
+        "email": "eshop@northfinder.cz",
         "hours": "Pondělí - Pátek 8:00 – 16:00",
-        "phone": "+421 233 418 364",
+        "phone": "+420 253 253 229",
         "subtitle": "Rádi vám poradíme"
       },
       "partnership": {
@@ -1272,8 +1272,8 @@
   },
   "footer": {
     "contact": {
-      "phone": "+421 233 418 364",
-      "email": "eshop@northfinder.com",
+      "phone": "+420 253 253 229",
+      "email": "eshop@northfinder.cz",
       "contact_us": "Kontaktujte nás"
     },
     "change": "Změnit",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -444,9 +444,9 @@
       },
       "info": {
         "address": "Rastislavova 109, 951 41 Lužianky, Szlovákia",
-        "email": "eshop@northfinder.com",
+        "email": "eshop@northfinder.hu",
         "hours": "Hétfő - Péntek 8:00 – 16:00",
-        "phone": "+421 233 418 364",
+        "phone": "+36 19 555 807",
         "subtitle": "Szívesen segítünk"
       },
       "partnership": {
@@ -1383,8 +1383,8 @@
   },
   "footer": {
     "contact": {
-      "phone": "+421 233 418 364",
-      "email": "eshop@northfinder.sk",
+      "phone": "+36 19 555 807",
+      "email": "eshop@northfinder.hu",
       "contact_us": "Kapcsolat"
     },
     "change": "Módosítás",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -458,9 +458,9 @@
       },
       "info": {
         "address": "Rastislavova 109, 951 41 Lužianky, Słowacja",
-        "phone": "+421 233 418 364",
+        "phone": "+48 729 086 043",
         "hours": "Poniedziałek - Piątek 8:00 – 16:00",
-        "email": "eshop@northfinder.sk",
+        "email": "eshop@northfinder.pl",
         "subtitle": "Chętnie Ci poradzimy"
       },
       "partnership": {
@@ -1438,8 +1438,8 @@
     "copyright": "© Copyright Northfinder {{ year }} / Wszelkie prawa zastrzeżone",
     "contact_us": "Skontaktuj się z nami",
     "contact": {
-      "phone": "+421 233 418 364",
-      "email": "eshop@northfinder.sk",
+      "phone": "+48 729 086 043",
+      "email": "eshop@northfinder.pl",
       "contact_us": "Skontaktuj się z nami"
     }
   },

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -443,10 +443,10 @@
         "write_to_us": "Scrieți-ne"
       },
       "info": {
-        "address": "Rastislavova 109, 951 41 Lužianky, Slovakia",
-        "email": "eshop@northfinder.com",
-        "hours": "Luni - Vineri 8:00 – 16:00",
-        "phone": "+421 233 418 364",
+        "address": "Str. Tăietura Turcului Nr. 47 H1, 400285 Cluj-Napoca, România",
+        "email": "eshop@northfinder.ro",
+        "hours": "Luni - Vineri 9:00 – 17:00",
+        "phone": "+40 312 208 366",
         "subtitle": "Suntem bucuroși să vă sfătuim"
       },
       "partnership": {
@@ -1265,8 +1265,8 @@
   },
   "footer": {
     "contact": {
-      "phone": "+421 233 418 364",
-      "email": "eshop@northfinder.com",
+      "phone": "+40 312 208 366",
+      "email": "eshop@northfinder.ro",
       "contact_us": "Contactați-ne"
     },
     "change": "Schimbă",

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -1480,7 +1480,7 @@
     "copyright": "© Copyright Northfinder {{ year }}",
     "contact_us": "Napíšte nám",
     "contact": {
-      "phone": "+421 482 901 715 ",
+      "phone": "+421 482 901 715",
       "email": "eshop@northfinder.sk",
       "contact_us": "Napíšte nám"
     }

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -15,23 +15,10 @@
 {%- endstyle -%}
 
 {%- liquid
-  assign contact_email = settings.contact_email
-  assign contact_phone = settings.contact_phone
-  assign contact_address = settings.contact_address
-  assign contact_hours = settings.contact_hours
-  if localization.market.handle != blank
-    # Market overrides are merchant-managed. Do not fall back to default-market values.
-    assign contact_email = settings.market_contact_email
-    assign contact_phone = settings.market_contact_phone
-    assign contact_address = settings.market_contact_address
-    assign contact_hours = settings.market_contact_hours
-  endif
-  if localization.language.iso_code == 'de'
-    assign contact_email = 'templates.contact.info.email' | t
-    assign contact_phone = 'templates.contact.info.phone' | t
-    assign contact_address = 'templates.contact.info.address' | t
-    assign contact_hours = 'templates.contact.info.hours' | t
-  endif
+  assign contact_email = 'templates.contact.info.email' | t
+  assign contact_phone = 'templates.contact.info.phone' | t
+  assign contact_address = 'templates.contact.info.address' | t
+  assign contact_hours = 'templates.contact.info.hours' | t
 -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient bg-gray-100">
@@ -49,9 +36,9 @@
             </svg>
           </div>
           <div class="contact-info__content">
-            {%- if contact_address != blank or localization.market.handle == blank -%}
+            {%- if contact_address != blank -%}
               <p class="contact-info__text">
-                {%- if contact_address != blank -%}{{ contact_address | escape }}{%- else -%}{{ 'templates.contact.info.address' | t }}{%- endif -%}
+                {{- contact_address | escape -}}
               </p>
             {%- endif -%}
           </div>
@@ -72,10 +59,10 @@
           </div>
           <div class="contact-info__content">
             <p class="contact-info__text">
-              {%- if contact_phone != blank -%}<a href="tel:{{ contact_phone | remove: ' ' | escape }}">{{ contact_phone | escape }}</a>{%- elsif localization.market.handle == blank -%}{{ 'templates.contact.info.phone' | t }}{%- endif -%}
+              {%- if contact_phone != blank -%}<a href="tel:{{ contact_phone | remove: ' ' | escape }}">{{ contact_phone | escape }}</a>{%- endif -%}
             </p>
             <p class="contact-info__hours">
-              {%- if contact_hours != blank -%}{{ contact_hours | escape }}{%- elsif localization.market.handle == blank -%}{{ 'templates.contact.info.hours' | t }}{%- endif -%}
+              {{- contact_hours | escape -}}
             </p>
           </div>
         </div>
@@ -96,7 +83,7 @@
           </div>
           <div class="contact-info__content">
             <p class="contact-info__text">
-              {%- if contact_email != blank -%}<a href="mailto:{{ contact_email | escape }}">{{ contact_email | escape }}</a>{%- elsif localization.market.handle == blank -%}{{ 'templates.contact.info.email' | t }}{%- endif -%}
+              {%- if contact_email != blank -%}<a href="mailto:{{ contact_email | escape }}">{{ contact_email | escape }}</a>{%- endif -%}
             </p>
           </div>
         </div>

--- a/sections/contact-partnership.liquid
+++ b/sections/contact-partnership.liquid
@@ -1,22 +1,9 @@
 {{ 'section-contact-partnership.css' | asset_url | stylesheet_tag }}
 
 {%- liquid
-  assign partnership_email = section.settings.contact_email
-  assign partnership_name = section.settings.contact_name
-  assign partnership_phone = section.settings.contact_phone
-  if localization.market.handle != blank
-    # Market overrides are merchant-managed. Do not fall back to default-market values.
-    assign partnership_email = settings.market_contact_person_email
-    assign partnership_name = settings.market_contact_person_name
-    assign partnership_phone = settings.market_contact_person_phone
-  elsif partnership_email == blank
-    assign partnership_email = settings.contact_email
-  endif
-  if localization.language.iso_code == 'de'
-    assign partnership_email = 'templates.contact.partnership.contact_email' | t
-    assign partnership_name = 'templates.contact.partnership.contact_name' | t
-    assign partnership_phone = 'templates.contact.partnership.contact_phone' | t
-  endif
+  assign partnership_email = 'templates.contact.partnership.contact_email' | t
+  assign partnership_name = 'templates.contact.partnership.contact_name' | t
+  assign partnership_phone = 'templates.contact.partnership.contact_phone' | t
 -%}
 
 {%- style -%}
@@ -64,8 +51,10 @@
               {%- if section.settings.contact_image != blank -%}
                 <img
                   src="{{ section.settings.contact_image | image_url: width: 70 }}"
-                  alt="{{ section.settings.contact_name | default: 'Contact person' | escape }}"
+                  alt="{{ partnership_name | escape }}"
                   class="contact-partnership__avatar-image"
+                  width="70"
+                  height="70"
                 >
               {%- endif -%}
             </div>
@@ -75,8 +64,6 @@
             <p class="contact-partnership__name">
               {%- if partnership_name != blank -%}
                 {{ partnership_name | escape }}
-              {%- elsif localization.market.handle == blank -%}
-                {{ 'templates.contact.partnership.contact_name' | t }}
               {%- endif -%}
             </p>
 
@@ -130,27 +117,9 @@
       "default": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>"
     },
     {
-      "type": "text",
-      "id": "contact_name",
-      "label": "Contact Person Name",
-      "default": "Contact Person"
-    },
-    {
       "type": "image_picker",
       "id": "contact_image",
       "label": "Contact Person Image"
-    },
-    {
-      "type": "text",
-      "id": "contact_email",
-      "label": "Contact Email",
-      "default": "partners@northfinder.sk"
-    },
-    {
-      "type": "text",
-      "id": "contact_phone",
-      "label": "Contact Phone",
-      "default": "+421 944 111 222"
     },
     {
       "type": "color_scheme",

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -174,13 +174,8 @@
   if localization.market.handle != blank and settings.market_social_vimeo_link != blank
     assign market_social_vimeo_link = settings.market_social_vimeo_link
   endif
-  assign market_contact_phone = settings.contact_phone
-  assign market_contact_email = settings.contact_email
-  if localization.market.handle != blank
-    # Market overrides are merchant-managed. Do not fall back to default-market values.
-    assign market_contact_phone = settings.market_contact_phone
-    assign market_contact_email = settings.market_contact_email
-  endif
+  assign contact_phone = 'templates.contact.info.phone' | t
+  assign contact_email = 'templates.contact.info.email' | t
     assign has_social_icons = true
     if market_social_facebook_link == blank and market_social_instagram_link == blank and market_social_youtube_link == blank and market_social_tiktok_link == blank and market_social_twitter_link == blank and market_social_pinterest_link == blank and market_social_snapchat_link == blank and market_social_tumblr_link == blank and market_social_vimeo_link == blank
       assign has_social_icons = false
@@ -322,14 +317,6 @@
                           <div class="rte">{{ settings.brand_description }}</div>
                         {%- endif -%}
                       {% endcomment %}
-                      {%- liquid
-                        assign contact_phone = market_contact_phone
-                        assign contact_email = market_contact_email
-                        if localization.language.iso_code == 'de'
-                          assign contact_phone = 'templates.contact.info.phone' | t
-                          assign contact_email = 'templates.contact.info.email' | t
-                        endif
-                      -%}
                       <div class="flex flex-col w-full gap-y-3 [&_a]:flex [&_a]:items-center [&_a]:gap-2 [&_a]:text-gray-850 [&_a]:text-sm [&_a]:hover:text-accent [&_a]:transition-colors">
                         {%- if contact_phone != blank -%}
                           <a href="tel:{{ contact_phone | remove: ' ' | escape }}" class="flex_address">

--- a/templates/page.contact.json
+++ b/templates/page.contact.json
@@ -41,10 +41,7 @@
         "background_image": "shopify://shop_images/Rectangle_1812.png",
         "heading": "",
         "description": "<p>Seeking to sell premium Northfinder products? Partner with us for high-quality, dependable outdoor gear that customers will love.</p>",
-        "contact_name": "",
         "contact_image": "shopify://shop_images/Ellipse_7.png",
-        "contact_email": "",
-        "contact_phone": "",
         "color_scheme": "scheme-1",
         "padding_top": 36,
         "padding_bottom": 36


### PR DESCRIPTION
## Summary

- make locale translations the sole source of truth for contact-page, footer, and partnership contact details
- remove obsolete global, market, and section-level contact overrides that caused blank market values to hide contact information
- restore provenance-backed localized customer-service details for Bulgarian, Czech, Hungarian, Polish, and Romanian storefront languages
- let missing locale-specific partnership fields fall back to `en.default` instead of inventing market data
- remove dead contact settings from the theme schema and contact template

## Root cause

The contact renderer switched to `market_contact_*` settings and intentionally stopped falling back to global data for active markets. Most market overrides were blank, so contact details disappeared from contact pages and the footer. German was later special-cased by language, which left the resolution path inconsistent.

This change removes market-aware contact resolution entirely. Every locale now resolves the same translation keys:

- `templates.contact.info.*`
- `templates.contact.partnership.*`

## Locale sources

Updated customer-service values are backed by official Northfinder localized pages or existing git history. Values without locale-specific provenance fall back through Shopify translations to `locales/en.default.json`.

## Validation

- Shopify Theme Check passed for all modified theme and locale files
- effective fallback coverage verified for all selector locales: `bg`, `cs`, `de`, `en`, `hr`, `hu`, `pl`, `ro`, `sk`, `sl`
- `pnpm test:ci`: 25 tests passed
- `git diff --check`: passed

## Excluded workspace changes

The existing `pnpm-lock.yaml`, `.orca/`, and settings backup changes are not included in this PR.
