### PR TITLE
Server-render the initial PDP gallery media

### DIFF
--- a/assets/product-media-gallery-runtime.js
+++ b/assets/product-media-gallery-runtime.js
@@ -35,8 +35,6 @@
     options: parseJson(root.querySelector("[data-gallery-options]"), {}),
   });
 
-  const mediaFilename = (url) => url.split("/").pop().split("?")[0].toLowerCase();
-
   class ProductMediaGalleryController {
     constructor(root) {
       this.root = root;
@@ -48,6 +46,8 @@
       this.processMediaTimeout = null;
       this.isDestroyed = false;
       this.isExpanded = false;
+      this.sequence = [];
+      this.hasHydrated = false;
 
       this.handleDocumentChange = this.handleDocumentChange.bind(this);
       this.handleVariantChange = this.handleVariantChange.bind(this);
@@ -114,7 +114,7 @@
 
     handleDocumentChange(event) {
       const colorControl = event.target.closest?.('[data-option-type="color"]');
-      if (!colorControl || !document.documentElement.contains(colorControl)) return;
+      if (!colorControl || !this.root.contains(colorControl)) return;
 
       const value = event.target.value;
       if (value) this.handleColorChange(value);
@@ -163,138 +163,165 @@
       if (this.isDestroyed) return;
 
       if (this.processMediaTimeout) clearTimeout(this.processMediaTimeout);
-      this.processMediaTimeout = setTimeout(() => {
+      const timer = setTimeout(() => {
         this.processMediaTimeout = null;
+        this.timers.delete(timer);
         this.render();
       }, CONFIG.debounceMs);
-      this.timers.add(this.processMediaTimeout);
+      this.processMediaTimeout = timer;
+      this.timers.add(timer);
     }
 
     render() {
       if (this.isDestroyed) return;
 
-      const mediaUrls = this.data.allMedia.map((media) =>
-        media.media_type === "video" && media.preview_image ? media.preview_image.src : media.src,
-      );
-      const videos = this.data.allMedia.filter((media) => media.media_type === "video");
-      let filteredUrls =
-        typeof window.filterMediaByColor === "function"
-          ? window.filterMediaByColor(mediaUrls, this.root.dataset.activeColor, this.data.colorMappings)
-          : mediaUrls;
-
-      const videoPreviewUrls = videos.map((video) => video.preview_image?.src).filter(Boolean);
-      filteredUrls = [...new Set([...filteredUrls, ...videoPreviewUrls])];
-
-      let images =
-        typeof window.sortImagesByDisplayRules === "function"
-          ? window.sortImagesByDisplayRules(filteredUrls, this.data.colorMappings)
-          : filteredUrls.map((url) => ({ url, hidden: false }));
-      images = this.reorderVideos(images, videos);
-      images.forEach((image, index) => {
-        image.hidden = index >= CONFIG.visibleCount;
+      this.loadSequenceResolver().then((resolveProductMediaSequence) => {
+        if (this.isDestroyed) return;
+        const initialMediaId = this.hasHydrated ? null : this.root.dataset.initialMediaId;
+        this.sequence = resolveProductMediaSequence({
+          media: this.data.allMedia,
+          activeColor: this.root.dataset.activeColor,
+          colorMappings: this.data.colorMappings,
+          initialMediaId,
+          visibleCount: CONFIG.visibleCount,
+        });
+        this.renderImages(this.sequence);
+        this.hasHydrated = true;
       });
-
-      if (!images.length) {
-        images = this.fallbackImages();
-      }
-
-      this.renderImages(images);
     }
 
-    reorderVideos(images, videos) {
-      if (!videos.length) return images;
-
-      const videoItems = images.filter((item) =>
-        videos.some((video) => {
-          const preview = video.preview_image?.src;
-          return preview && (item.url === preview || item.url.includes(preview.split("?")[0]));
-        }),
-      );
-      const imageItems = images.filter((item) => !videoItems.includes(item));
-      if (!videoItems.length || !imageItems.length) return images;
-
-      return [imageItems[0], ...videoItems, ...imageItems.slice(1)];
+    async loadSequenceResolver() {
+      const module = await import("./product-media-gallery-sequence.js");
+      return module.resolveProductMediaSequence;
     }
 
-    fallbackImages() {
-      const fallback = this.data.allMedia
-        .map((media) => (media.media_type === "video" && media.preview_image ? media.preview_image.src : media.src))
-        .filter(Boolean)
-        .slice(0, 2);
-
-      return fallback.length
-        ? fallback.map((url) => ({ url, hidden: false }))
-        : [{ url: "placeholder", hidden: false }];
-    }
-
-    renderImages(images) {
+    renderImages(sequence) {
       this.destroySwiper();
-      this.sliderWrapper.replaceChildren();
-      this.grid.replaceChildren();
-
-      const normalizedImages = images.length === 1 ? [images[0], images[0]] : images;
-      const firstUrl = normalizedImages[0]?.url;
-
-      for (const [index, image] of normalizedImages.entries()) {
-        const mediaItem = this.createMediaItem(image.url, index);
-        if (!mediaItem) continue;
-
-        this.sliderWrapper.appendChild(mediaItem.cloneNode(true));
-
-        if (index === 0 || image.url !== firstUrl) {
-          if (image.hidden && !this.isExpanded) mediaItem.classList.add("hidden");
-          if (image.hidden) mediaItem.classList.add("expandable-item");
-          this.grid.appendChild(mediaItem);
-        }
+      if (!sequence.length) {
+        this.mobileGallery.classList.add("loaded");
+        this.grid.classList.add("loaded");
+        return;
       }
 
-      this.updateToggle(normalizedImages);
+      this.reconcileContainer(this.sliderWrapper, sequence, true);
+      this.reconcileContainer(this.grid, sequence, false);
+      this.updateToggle(sequence);
       this.initializeSwiper();
       this.mobileGallery.classList.add("loaded");
       this.grid.classList.add("loaded");
       this.ensureVideosAutoplay();
     }
 
-    createMediaItem(url, index) {
-      const mediaObject = this.data.allMedia.find((media) => {
-        const source = media.media_type === "video" ? media.preview_image?.src : media.src;
-        return source && mediaFilename(url) === mediaFilename(source);
-      });
-      const mediaId = mediaObject?.id || `generated-${index}`;
-      const item = document.createElement("div");
-      item.className = `swiper-slide product__media-item${index === 0 ? " is-active" : ""}`;
-      item.id = `Slide-${this.sectionId}-${mediaId}`;
-      item.dataset.mediaId = `${this.sectionId}-${mediaId}`;
-      item.dataset.mediaType = mediaObject?.media_type || "image";
+    reconcileContainer(container, sequence, isMobile) {
+      container.querySelector("#desktop-gallery-loading")?.remove();
+      const existingItems = [...container.children].filter((child) => child.matches?.("[data-gallery-item]"));
+      const existingById = new Map(existingItems.map((item) => [item.dataset.galleryMediaId, item]));
+      const retained = new Set();
+      const fragment = document.createDocumentFragment();
+
+      for (const [index, item] of sequence.entries()) {
+        const mediaId = String(item.mediaId || `generated-${index}`);
+        let mediaItem = existingById.get(mediaId);
+        if (!mediaItem) mediaItem = this.createMediaItem(item, index);
+        if (!mediaItem) continue;
+
+        const preserveFirstImage =
+          index === 0 &&
+          !mediaItem.dataset.galleryHydrated &&
+          mediaItem.dataset.galleryMediaId === mediaId &&
+          item.mediaType === "image";
+        this.updateMediaItem(mediaItem, item, index, isMobile, preserveFirstImage);
+        mediaItem.dataset.galleryHydrated = "true";
+        retained.add(mediaItem);
+        fragment.appendChild(mediaItem);
+      }
+
+      for (const existingItem of existingItems) {
+        if (!retained.has(existingItem)) existingItem.remove();
+      }
+      container.appendChild(fragment);
+    }
+
+    createMediaItem(sequenceItem, index) {
+      const mediaId = sequenceItem.mediaId || `generated-${index}`;
+      const mediaItem = document.createElement("div");
+      mediaItem.className = "swiper-slide product__media-item";
+      mediaItem.dataset.galleryItem = "true";
 
       const wrapper = document.createElement("div");
       wrapper.className = "product__media media relative w-full h-0";
-      wrapper.style.cssText = "--ratio: 1; --preview-ratio: 1; padding-bottom: 100%;";
+      wrapper.style.cssText = "--ratio: 1; --preview-ratio: 1; aspect-ratio: 1; padding-bottom: 100%;";
       const content = document.createElement("div");
       content.className = "absolute inset-0 w-full h-full";
 
-      if (mediaObject?.media_type === "video") {
-        content.appendChild(this.createVideo(mediaObject));
-      } else if (url === "placeholder") {
-        content.appendChild(this.createPlaceholder());
-      } else {
-        const image = document.createElement("img");
-        image.src = mediaObject?.src || url;
-        image.alt = mediaObject?.alt || "Product image";
-        image.className = "media-item w-full h-full object-cover product-lightbox-img";
-        image.loading = index === 0 ? "eager" : "lazy";
-        if (mediaObject?.width) image.width = mediaObject.width;
-        if (mediaObject?.height) image.height = mediaObject.height;
-        image.addEventListener("click", (event) => {
-          event.preventDefault();
-          this.openLightbox(index);
-        });
-        content.appendChild(image);
+      wrapper.appendChild(content);
+      mediaItem.appendChild(wrapper);
+      this.updateMediaItem(mediaItem, sequenceItem, index, true);
+      return mediaItem;
+    }
+
+    updateMediaItem(item, sequenceItem, index, isMobile, preserveFirstImage = false) {
+      const media = sequenceItem.media;
+      const mediaId = String(sequenceItem.mediaId || `generated-${index}`);
+      item.id = `Slide-${this.sectionId}-${isMobile ? "mobile" : "desktop"}-${mediaId}`;
+      item.dataset.mediaId = mediaId;
+      item.dataset.galleryMediaId = mediaId;
+      item.dataset.mediaType = sequenceItem.mediaType || "image";
+      item.classList.toggle("is-active", index === 0);
+      item.classList.toggle("hidden", Boolean(sequenceItem.hidden && !this.isExpanded && !isMobile));
+      item.classList.toggle("expandable-item", Boolean(sequenceItem.hidden && !isMobile));
+
+      const wrapper = item.querySelector(".product__media") || item.firstElementChild;
+      const content = wrapper?.firstElementChild;
+      if (!wrapper || !content) return;
+      const image = media?.media_type === "image" ? media : media?.preview_image;
+      const ratio = image?.width && image?.height ? image.width / image.height : 1;
+      wrapper.style.cssText = `--ratio: ${ratio}; --preview-ratio: ${ratio}; aspect-ratio: ${ratio}; padding-bottom: ${100 / ratio}%;`;
+
+      if (media?.media_type === "video") {
+        if (!content.querySelector("video")) {
+          this.setContent(content, this.createVideo(media));
+        }
+        return;
       }
 
-      wrapper.appendChild(content);
-      item.appendChild(wrapper);
-      return item;
+      if (media?.media_type === "model") {
+        this.setContent(content, this.createModel(media));
+        return;
+      }
+
+      if (media?.media_type === "external_video") {
+        this.setContent(content, this.createExternalVideo(media));
+        return;
+      }
+
+      if (!image?.src) {
+        this.setContent(content, this.createPlaceholder());
+        return;
+      }
+
+      let imageElement = content.querySelector("img");
+      if (!imageElement) {
+        imageElement = document.createElement("img");
+        this.setContent(content, imageElement);
+      }
+      if (!preserveFirstImage) imageElement.src = image.src;
+      imageElement.alt = image.alt || this.data.options.productTitle || "Product image";
+      imageElement.className = "media-item w-full h-full object-cover product-lightbox-img";
+      imageElement.loading = index === 0 ? "eager" : "lazy";
+      imageElement.decoding = "async";
+      if (index === 0) imageElement.fetchPriority = "high";
+      if (image.width) imageElement.width = image.width;
+      if (image.height) imageElement.height = image.height;
+      imageElement.onclick = (event) => {
+        event.preventDefault();
+        this.openLightbox(index);
+      };
+    }
+
+    setContent(container, content) {
+      while (container.firstChild) container.removeChild(container.firstChild);
+      container.appendChild(content);
     }
 
     createPlaceholder() {
@@ -302,6 +329,30 @@
       placeholder.className = "w-full h-full bg-gray-100 flex items-center justify-center";
       placeholder.innerHTML = '<span aria-hidden="true"></span>';
       return placeholder;
+    }
+
+    createModel(media) {
+      const model = document.createElement("model-viewer");
+      model.className = "w-full h-full";
+      model.setAttribute("alt", media.alt || this.data.options.productTitle || "Product model");
+      if (media.sources?.[0]?.url) model.setAttribute("src", media.sources[0].url);
+      if (media.preview_image?.src) model.setAttribute("poster", media.preview_image.src);
+      return model;
+    }
+
+    createExternalVideo(media) {
+      const frame = document.createElement("div");
+      frame.className = "external-video-container relative w-full h-full";
+      const image = media.preview_image;
+      if (image?.src) {
+        const poster = document.createElement("img");
+        poster.src = image.src;
+        poster.alt = media.alt || this.data.options.productTitle || "Product video";
+        poster.className = "w-full h-full object-cover";
+        poster.loading = "lazy";
+        frame.appendChild(poster);
+      }
+      return frame;
     }
 
     createVideo(media) {
@@ -495,25 +546,8 @@
     observer.observe(document.body, { childList: true, subtree: true });
   };
 
-  const loadUtilities = async () => {
-    if (
-      typeof window.parseImageUrl === "function" &&
-      typeof window.filterMediaByColor === "function" &&
-      typeof window.sortImagesByDisplayRules === "function"
-    ) {
-      return;
-    }
-
-    const utils = await import("./product-utils.module.js");
-    window.parseImageUrl = utils.parseImageUrl;
-    window.sortImagesByDisplayRules = utils.sortImagesByDisplayRules;
-    window.filterMediaByColor = utils.filterMediaByColor;
-  };
-
   const bootstrap = () => {
-    loadUtilities()
-      .catch(() => {})
-      .finally(initialize);
+    initialize();
   };
 
   if (document.readyState === "loading") {
@@ -521,6 +555,4 @@
   } else {
     bootstrap();
   }
-
-  window.ProductMediaGalleryController = ProductMediaGalleryController;
 })();

--- a/assets/product-media-gallery-sequence.js
+++ b/assets/product-media-gallery-sequence.js
@@ -1,0 +1,119 @@
+import { filterMediaByColor, sortImagesByDisplayRules } from "./product-utils.module.js";
+
+const VISIBLE_MEDIA_COUNT = 6;
+
+const mediaSource = (media) => {
+  if (!media) return "";
+  if (media.media_type === "image") return media.src || media.preview_image?.src || "";
+  return media.preview_image?.src || media.src || "";
+};
+
+const mediaFilename = (url) => (url || "").split("/").pop().split("?")[0].toLowerCase();
+
+const uniqueSources = (media) => {
+  const sources = [];
+  const seen = new Set();
+
+  for (const item of media) {
+    const source = mediaSource(item);
+    if (!source || seen.has(source)) continue;
+    seen.add(source);
+    sources.push(source);
+  }
+
+  return sources;
+};
+
+const findMediaForSource = (media, source) => {
+  const filename = mediaFilename(source);
+  return media.find((item) => {
+    const itemSource = mediaSource(item);
+    return itemSource && (itemSource === source || mediaFilename(itemSource) === filename);
+  });
+};
+
+const reorderVideos = (items) => {
+  const videoItems = items.filter((item) => item.media?.media_type === "video");
+  const imageItems = items.filter((item) => item.media?.media_type !== "video");
+
+  if (!videoItems.length || !imageItems.length) return items;
+  return [imageItems[0], ...videoItems, ...imageItems.slice(1)];
+};
+
+/**
+ * Resolve the one gallery sequence used by both SSR metadata and hydration.
+ *
+ * The filtering and sorting functions are deliberately the existing product
+ * utility functions. This keeps exact/partial/reference-id/fallback matching
+ * and display priorities in one deterministic contract while retaining the
+ * original Shopify media objects.
+ */
+export function resolveProductMediaSequence({
+  media = [],
+  activeColor = "",
+  colorMappings = null,
+  initialMediaId = null,
+  visibleCount = VISIBLE_MEDIA_COUNT,
+} = {}) {
+  const allMedia = Array.isArray(media) ? media : [];
+  const allSources = uniqueSources(allMedia);
+  let filteredSources = filterMediaByColor(allSources, activeColor, colorMappings);
+
+  const videoSources = allMedia
+    .filter((item) => item.media_type === "video")
+    .map(mediaSource)
+    .filter(Boolean);
+  filteredSources = [...new Set([...filteredSources, ...videoSources])];
+
+  let sorted = sortImagesByDisplayRules(filteredSources, colorMappings);
+  sorted = Array.isArray(sorted) ? sorted : [];
+
+  let sequence = sorted
+    .map((item) => {
+      const source = typeof item === "string" ? item : item?.url;
+      const matchedMedia = findMediaForSource(allMedia, source);
+      if (!source || !matchedMedia) return null;
+
+      return {
+        media: matchedMedia,
+        mediaId: matchedMedia.id,
+        mediaType: matchedMedia.media_type || "image",
+        source,
+        hidden: false,
+      };
+    })
+    .filter(Boolean);
+
+  sequence = reorderVideos(sequence);
+
+  if (!sequence.length) {
+    sequence = allMedia
+      .slice(0, 2)
+      .map((item) => {
+        const source = mediaSource(item);
+        if (!source) return null;
+        return {
+          media: item,
+          mediaId: item.id,
+          mediaType: item.media_type || "image",
+          source,
+          hidden: false,
+        };
+      })
+      .filter(Boolean);
+  }
+
+  if (initialMediaId !== null && initialMediaId !== undefined && sequence.length > 1) {
+    const initialIndex = sequence.findIndex((item) => String(item.mediaId) === String(initialMediaId));
+    if (initialIndex > 0) {
+      sequence = [sequence[initialIndex], ...sequence.slice(0, initialIndex), ...sequence.slice(initialIndex + 1)];
+    }
+  }
+
+  return sequence.map((item, index) => ({
+    ...item,
+    hidden: index >= visibleCount,
+  }));
+}
+
+export { mediaSource };

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -1,7 +1,7 @@
 <!doctype html>
 <html class="js" lang="{{ request.locale.iso_code }}">
   <head>
- {%- render 'ecom_header' -%}
+    {%- render 'ecom_header' -%}
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -42,7 +42,11 @@
         {%- endif -%}
       {%- endfor -%}
     {%- elsif template.name == 'product' and product.featured_image -%}
-      <link rel="preload" as="image" href="{{ product.featured_image | image_url: width: 800 }}">
+      <link
+        rel="preload"
+        as="image"
+        href="{{ product.selected_or_first_available_variant.featured_media.preview_image | default: product.selected_or_first_available_variant.featured_image | default: product.featured_image | image_url: width: 800 }}"
+      >
     {%- endif -%}
 
     <title>
@@ -81,235 +85,240 @@
     %}
 
     {% style %}
-                {{ settings.type_body_font | font_face: font_display: 'swap' }}
-                {{ body_font_500 | font_face: font_display: 'swap' }}
-                {{ body_font_600 | font_face: font_display: 'swap' }}
-                {{ body_font_bold | font_face: font_display: 'swap' }}
-                {{ body_font_italic | font_face: font_display: 'swap' }}
-                {{ body_font_bold_italic | font_face: font_display: 'swap' }}
-                {{ settings.type_header_font | font_face: font_display: 'swap' }}
+      {{ settings.type_body_font | font_face: font_display: 'swap' }}
+      {{ body_font_500 | font_face: font_display: 'swap' }}
+      {{ body_font_600 | font_face: font_display: 'swap' }}
+      {{ body_font_bold | font_face: font_display: 'swap' }}
+      {{ body_font_italic | font_face: font_display: 'swap' }}
+      {{ body_font_bold_italic | font_face: font_display: 'swap' }}
+      {{ settings.type_header_font | font_face: font_display: 'swap' }}
 
-                {% for scheme in settings.color_schemes -%}
-                  {% assign scheme_classes = scheme_classes | append: ', .color-' | append: scheme.id %}
-                  {% if forloop.index == 1 -%}
-                    :root,
-                  {%- endif %}
-                  .color-{{ scheme.id }} {
-                    --color-base-background: {{ scheme.settings.background.red }},{{ scheme.settings.background.green }},{{ scheme.settings.background.blue }};
-                  {% if scheme.settings.background_gradient != empty %}
-                    --gradient-background: {{ scheme.settings.background_gradient }};
-                  {% else %}
-                    --gradient-background: {{ scheme.settings.background }};
-                  {% endif %}
+      {% for scheme in settings.color_schemes -%}
+        {% assign scheme_classes = scheme_classes | append: ', .color-' | append: scheme.id %}
+        {% if forloop.index == 1 -%}
+          :root,
+        {%- endif %}
+        .color-{{ scheme.id }} {
+          --color-base-background: {{ scheme.settings.background.red }},{{ scheme.settings.background.green }},{{ scheme.settings.background.blue }};
+        {% if scheme.settings.background_gradient != empty %}
+          --gradient-background: {{ scheme.settings.background_gradient }};
+        {% else %}
+          --gradient-background: {{ scheme.settings.background }};
+        {% endif %}
 
-                  {% liquid
-                    assign background_color = scheme.settings.background
-                    assign background_color_brightness = background_color | color_brightness
-                    if background_color_brightness <= 26
-                      assign background_color_contrast = background_color | color_lighten: 50
-                    elsif background_color_brightness <= 65
-                      assign background_color_contrast = background_color | color_lighten: 5
-                    else
-                      assign background_color_contrast = background_color | color_darken: 25
-                    endif
-                  %}
+        {% liquid
+          assign background_color = scheme.settings.background
+          assign background_color_brightness = background_color | color_brightness
+          if background_color_brightness <= 26
+            assign background_color_contrast = background_color | color_lighten: 50
+          elsif background_color_brightness <= 65
+            assign background_color_contrast = background_color | color_lighten: 5
+          else
+            assign background_color_contrast = background_color | color_darken: 25
+          endif
+        %}
 
-                  --color-base-foreground: {{ scheme.settings.text.red }},{{ scheme.settings.text.green }},{{ scheme.settings.text.blue }};
-                  --color-base-background-contrast: {{ background_color_contrast.red }},{{ background_color_contrast.green }},{{ background_color_contrast.blue }};
-                  --color-base-shadow: {{ scheme.settings.shadow.red }},{{ scheme.settings.shadow.green }},{{ scheme.settings.shadow.blue }};
-                  --color-base-button: {{ scheme.settings.button.red }},{{ scheme.settings.button.green }},{{ scheme.settings.button.blue }};
-                  --color-base-button-text: {{ scheme.settings.button_label.red }},{{ scheme.settings.button_label.green }},{{ scheme.settings.button_label.blue }};
-                  --color-base-secondary-button: {{ scheme.settings.background.red }},{{ scheme.settings.background.green }},{{ scheme.settings.background.blue }};
-                  --color-base-secondary-button-text: {{ scheme.settings.secondary_button_label.red }},{{ scheme.settings.secondary_button_label.green }},{{ scheme.settings.secondary_button_label.blue }};
-                  --color-base-link: {{ scheme.settings.secondary_button_label.red }},{{ scheme.settings.secondary_button_label.green }},{{ scheme.settings.secondary_button_label.blue }};
-                  --color-base-badge-foreground: {{ scheme.settings.text.red }},{{ scheme.settings.text.green }},{{ scheme.settings.text.blue }};
-                  --color-base-badge-background: {{ scheme.settings.background.red }},{{ scheme.settings.background.green }},{{ scheme.settings.background.blue }};
-                  --color-base-badge-border: {{ scheme.settings.text.red }},{{ scheme.settings.text.green }},{{ scheme.settings.text.blue }};
-                  --payment-terms-background-color: rgb({{ scheme.settings.background.rgb }});
-                }
-                {% endfor %}
+        --color-base-foreground: {{ scheme.settings.text.red }},{{ scheme.settings.text.green }},{{ scheme.settings.text.blue }};
+        --color-base-background-contrast: {{ background_color_contrast.red }},{{ background_color_contrast.green }},{{ background_color_contrast.blue }};
+        --color-base-shadow: {{ scheme.settings.shadow.red }},{{ scheme.settings.shadow.green }},{{ scheme.settings.shadow.blue }};
+        --color-base-button: {{ scheme.settings.button.red }},{{ scheme.settings.button.green }},{{ scheme.settings.button.blue }};
+        --color-base-button-text: {{ scheme.settings.button_label.red }},{{ scheme.settings.button_label.green }},{{ scheme.settings.button_label.blue }};
+        --color-base-secondary-button: {{ scheme.settings.background.red }},{{ scheme.settings.background.green }},{{ scheme.settings.background.blue }};
+        --color-base-secondary-button-text: {{ scheme.settings.secondary_button_label.red }},{{ scheme.settings.secondary_button_label.green }},{{ scheme.settings.secondary_button_label.blue }};
+        --color-base-link: {{ scheme.settings.secondary_button_label.red }},{{ scheme.settings.secondary_button_label.green }},{{ scheme.settings.secondary_button_label.blue }};
+        --color-base-badge-foreground: {{ scheme.settings.text.red }},{{ scheme.settings.text.green }},{{ scheme.settings.text.blue }};
+        --color-base-badge-background: {{ scheme.settings.background.red }},{{ scheme.settings.background.green }},{{ scheme.settings.background.blue }};
+        --color-base-badge-border: {{ scheme.settings.text.red }},{{ scheme.settings.text.green }},{{ scheme.settings.text.blue }};
+        --payment-terms-background-color: rgb({{ scheme.settings.background.rgb }});
+      }
+      {% endfor %}
 
-                {{ scheme_classes | prepend: 'body' }} {
-                  color: rgba(var(--color-base-foreground), 0.75);
-                  background-color: rgb(var(--color-base-background));
-                }
+      {{ scheme_classes | prepend: 'body' }} {
+        color: rgba(var(--color-base-foreground), 0.75);
+        background-color: rgb(var(--color-base-background));
+      }
 
-                :root {
-                  --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
-                  --font-body-style: {{ settings.type_body_font.style }};
-                  --font-body-weight: {{ settings.type_body_font.weight }};
-                  --font-body-weight-bold: {{ settings.type_body_font.weight | plus: 300 | at_most: 1000 }};
+      :root {
+        --font-body-family: {{ settings.type_body_font.family }}, {{ settings.type_body_font.fallback_families }};
+        --font-body-style: {{ settings.type_body_font.style }};
+        --font-body-weight: {{ settings.type_body_font.weight }};
+        --font-body-weight-bold: {{ settings.type_body_font.weight | plus: 300 | at_most: 1000 }};
 
-                  --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
-                  --font-heading-style: {{ settings.type_header_font.style }};
-                  --font-heading-weight: {{ settings.type_header_font.weight }};
+        --font-heading-family: {{ settings.type_header_font.family }}, {{ settings.type_header_font.fallback_families }};
+        --font-heading-style: {{ settings.type_header_font.style }};
+        --font-heading-weight: {{ settings.type_header_font.weight }};
 
-                  --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
-                  --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
+        --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
+        --font-heading-scale: {{ settings.heading_scale | times: 1.0 | divided_by: settings.body_scale }};
 
-                  --media-padding: {{ settings.media_padding }}px;
-                  --media-border-opacity: {{ settings.media_border_opacity | divided_by: 100.0 }};
-                  --media-border-width: {{ settings.media_border_thickness }}px;
-                  --media-radius: {{ settings.media_radius }}px;
-                  --media-shadow-opacity: {{ settings.media_shadow_opacity | divided_by: 100.0 }};
-                  --media-shadow-horizontal-offset: {{ settings.media_shadow_horizontal_offset }}px;
-                  --media-shadow-vertical-offset: {{ settings.media_shadow_vertical_offset }}px;
-                  --media-shadow-blur-radius: {{ settings.media_shadow_blur }}px;
-                  --media-shadow-visible: {% if settings.media_shadow_opacity > 0 %}1{% else %}0{% endif %};
+        --media-padding: {{ settings.media_padding }}px;
+        --media-border-opacity: {{ settings.media_border_opacity | divided_by: 100.0 }};
+        --media-border-width: {{ settings.media_border_thickness }}px;
+        --media-radius: {{ settings.media_radius }}px;
+        --media-shadow-opacity: {{ settings.media_shadow_opacity | divided_by: 100.0 }};
+        --media-shadow-horizontal-offset: {{ settings.media_shadow_horizontal_offset }}px;
+        --media-shadow-vertical-offset: {{ settings.media_shadow_vertical_offset }}px;
+        --media-shadow-blur-radius: {{ settings.media_shadow_blur }}px;
+        --media-shadow-visible: {% if settings.media_shadow_opacity > 0 %}1{% else %}0{% endif %};
 
-                  --page-width: {{ settings.page_width | divided_by: 16 }}rem;
-                  --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
+        --page-width: {{ settings.page_width | divided_by: 16 }}rem;
+        --page-width-margin: {% if settings.page_width == '1600' %}2{% else %}0{% endif %}rem;
 
-                  --product-card-image-padding: {{ settings.card_image_padding | divided_by: 10.0 }}rem;
-                  --product-card-corner-radius: {{ settings.card_corner_radius | divided_by: 10.0 }}rem;
-                  --product-card-text-alignment: {{ settings.card_text_alignment }};
-                  --product-card-border-width: {{ settings.card_border_thickness | divided_by: 10.0 }}rem;
-                  --product-card-border-opacity: {{ settings.card_border_opacity | divided_by: 100.0 }};
-                  --product-card-shadow-opacity: {{ settings.card_shadow_opacity | divided_by: 100.0 }};
-                  --product-card-shadow-visible: {% if settings.card_shadow_opacity > 0 %}1{% else %}0{% endif %};
-                  --product-card-shadow-horizontal-offset: {{ settings.card_shadow_horizontal_offset | divided_by: 10.0 }}rem;
-                  --product-card-shadow-vertical-offset: {{ settings.card_shadow_vertical_offset | divided_by: 10.0 }}rem;
-                  --product-card-shadow-blur-radius: {{ settings.card_shadow_blur | divided_by: 10.0 }}rem;
+        --product-card-image-padding: {{ settings.card_image_padding | divided_by: 10.0 }}rem;
+        --product-card-corner-radius: {{ settings.card_corner_radius | divided_by: 10.0 }}rem;
+        --product-card-text-alignment: {{ settings.card_text_alignment }};
+        --product-card-border-width: {{ settings.card_border_thickness | divided_by: 10.0 }}rem;
+        --product-card-border-opacity: {{ settings.card_border_opacity | divided_by: 100.0 }};
+        --product-card-shadow-opacity: {{ settings.card_shadow_opacity | divided_by: 100.0 }};
+        --product-card-shadow-visible: {% if settings.card_shadow_opacity > 0 %}1{% else %}0{% endif %};
+        --product-card-shadow-horizontal-offset: {{ settings.card_shadow_horizontal_offset | divided_by: 10.0 }}rem;
+        --product-card-shadow-vertical-offset: {{ settings.card_shadow_vertical_offset | divided_by: 10.0 }}rem;
+        --product-card-shadow-blur-radius: {{ settings.card_shadow_blur | divided_by: 10.0 }}rem;
 
-                  --collection-card-image-padding: {{ settings.collection_card_image_padding | divided_by: 10.0 }}rem;
-                  --collection-card-corner-radius: {{ settings.collection_card_corner_radius | divided_by: 10.0 }}rem;
-                  --collection-card-text-alignment: {{ settings.collection_card_text_alignment }};
-                  --collection-card-border-width: {{ settings.collection_card_border_thickness | divided_by: 10.0 }}rem;
-                  --collection-card-border-opacity: {{ settings.collection_card_border_opacity | divided_by: 100.0 }};
-                  --collection-card-shadow-opacity: {{ settings.collection_card_shadow_opacity | divided_by: 100.0 }};
-                  --collection-card-shadow-visible: {% if settings.collection_card_shadow_opacity > 0 %}1{% else %}0{% endif %};
-                  --collection-card-shadow-horizontal-offset: {{ settings.collection_card_shadow_horizontal_offset | divided_by: 10.0 }}rem;
-                  --collection-card-shadow-vertical-offset: {{ settings.collection_card_shadow_vertical_offset | divided_by: 10.0 }}rem;
-                  --collection-card-shadow-blur-radius: {{ settings.collection_card_shadow_blur | divided_by: 10.0 }}rem;
+        --collection-card-image-padding: {{ settings.collection_card_image_padding | divided_by: 10.0 }}rem;
+        --collection-card-corner-radius: {{ settings.collection_card_corner_radius | divided_by: 10.0 }}rem;
+        --collection-card-text-alignment: {{ settings.collection_card_text_alignment }};
+        --collection-card-border-width: {{ settings.collection_card_border_thickness | divided_by: 10.0 }}rem;
+        --collection-card-border-opacity: {{ settings.collection_card_border_opacity | divided_by: 100.0 }};
+        --collection-card-shadow-opacity: {{ settings.collection_card_shadow_opacity | divided_by: 100.0 }};
+        --collection-card-shadow-visible: {% if settings.collection_card_shadow_opacity > 0 %}1{% else %}0{% endif %};
+        --collection-card-shadow-horizontal-offset: {{ settings.collection_card_shadow_horizontal_offset | divided_by: 10.0 }}rem;
+        --collection-card-shadow-vertical-offset: {{ settings.collection_card_shadow_vertical_offset | divided_by: 10.0 }}rem;
+        --collection-card-shadow-blur-radius: {{ settings.collection_card_shadow_blur | divided_by: 10.0 }}rem;
 
-                  --blog-card-image-padding: {{ settings.blog_card_image_padding | divided_by: 10.0 }}rem;
-                  --blog-card-corner-radius: {{ settings.blog_card_corner_radius | divided_by: 10.0 }}rem;
-                  --blog-card-text-alignment: {{ settings.blog_card_text_alignment }};
-                  --blog-card-border-width: {{ settings.blog_card_border_thickness | divided_by: 10.0 }}rem;
-                  --blog-card-border-opacity: {{ settings.blog_card_border_opacity | divided_by: 100.0 }};
-                  --blog-card-shadow-opacity: {{ settings.blog_card_shadow_opacity | divided_by: 100.0 }};
-                  --blog-card-shadow-visible: {% if settings.blog_card_shadow_opacity > 0 %}1{% else %}0{% endif %};
-                  --blog-card-shadow-horizontal-offset: {{ settings.blog_card_shadow_horizontal_offset | divided_by: 10.0 }}rem;
-                  --blog-card-shadow-vertical-offset: {{ settings.blog_card_shadow_vertical_offset | divided_by: 10.0 }}rem;
-                  --blog-card-shadow-blur-radius: {{ settings.blog_card_shadow_blur | divided_by: 10.0 }}rem;
+        --blog-card-image-padding: {{ settings.blog_card_image_padding | divided_by: 10.0 }}rem;
+        --blog-card-corner-radius: {{ settings.blog_card_corner_radius | divided_by: 10.0 }}rem;
+        --blog-card-text-alignment: {{ settings.blog_card_text_alignment }};
+        --blog-card-border-width: {{ settings.blog_card_border_thickness | divided_by: 10.0 }}rem;
+        --blog-card-border-opacity: {{ settings.blog_card_border_opacity | divided_by: 100.0 }};
+        --blog-card-shadow-opacity: {{ settings.blog_card_shadow_opacity | divided_by: 100.0 }};
+        --blog-card-shadow-visible: {% if settings.blog_card_shadow_opacity > 0 %}1{% else %}0{% endif %};
+        --blog-card-shadow-horizontal-offset: {{ settings.blog_card_shadow_horizontal_offset | divided_by: 10.0 }}rem;
+        --blog-card-shadow-vertical-offset: {{ settings.blog_card_shadow_vertical_offset | divided_by: 10.0 }}rem;
+        --blog-card-shadow-blur-radius: {{ settings.blog_card_shadow_blur | divided_by: 10.0 }}rem;
 
-                  --badge-corner-radius: {{ settings.badge_corner_radius | divided_by: 10.0 }}rem;
+        --badge-corner-radius: {{ settings.badge_corner_radius | divided_by: 10.0 }}rem;
 
-                  --popup-border-width: {{ settings.popup_border_thickness }}px;
-                  --popup-border-opacity: {{ settings.popup_border_opacity | divided_by: 100.0 }};
-                  --popup-corner-radius: {{ settings.popup_corner_radius }}px;
-                  --popup-shadow-opacity: {{ settings.popup_shadow_opacity | divided_by: 100.0 }};
-                  --popup-shadow-horizontal-offset: {{ settings.popup_shadow_horizontal_offset }}px;
-                  --popup-shadow-vertical-offset: {{ settings.popup_shadow_vertical_offset }}px;
-                  --popup-shadow-blur-radius: {{ settings.popup_shadow_blur }}px;
+        --popup-border-width: {{ settings.popup_border_thickness }}px;
+        --popup-border-opacity: {{ settings.popup_border_opacity | divided_by: 100.0 }};
+        --popup-corner-radius: {{ settings.popup_corner_radius }}px;
+        --popup-shadow-opacity: {{ settings.popup_shadow_opacity | divided_by: 100.0 }};
+        --popup-shadow-horizontal-offset: {{ settings.popup_shadow_horizontal_offset }}px;
+        --popup-shadow-vertical-offset: {{ settings.popup_shadow_vertical_offset }}px;
+        --popup-shadow-blur-radius: {{ settings.popup_shadow_blur }}px;
 
-                  --drawer-border-width: {{ settings.drawer_border_thickness }}px;
-                  --drawer-border-opacity: {{ settings.drawer_border_opacity | divided_by: 100.0 }};
-                  --drawer-shadow-opacity: {{ settings.drawer_shadow_opacity | divided_by: 100.0 }};
-                  --drawer-shadow-horizontal-offset: {{ settings.drawer_shadow_horizontal_offset }}px;
-                  --drawer-shadow-vertical-offset: {{ settings.drawer_shadow_vertical_offset }}px;
-                  --drawer-shadow-blur-radius: {{ settings.drawer_shadow_blur }}px;
+        --drawer-border-width: {{ settings.drawer_border_thickness }}px;
+        --drawer-border-opacity: {{ settings.drawer_border_opacity | divided_by: 100.0 }};
+        --drawer-shadow-opacity: {{ settings.drawer_shadow_opacity | divided_by: 100.0 }};
+        --drawer-shadow-horizontal-offset: {{ settings.drawer_shadow_horizontal_offset }}px;
+        --drawer-shadow-vertical-offset: {{ settings.drawer_shadow_vertical_offset }}px;
+        --drawer-shadow-blur-radius: {{ settings.drawer_shadow_blur }}px;
 
-                  --spacing-sections-desktop: {{ settings.spacing_sections }}px;
-                  --spacing-sections-mobile: {% if settings.spacing_sections < 24 %}{{ settings.spacing_sections }}{% else %}{{ settings.spacing_sections | times: 0.7 | round | at_least: 20 }}{% endif %}px;
+        --spacing-sections-desktop: {{ settings.spacing_sections }}px;
+        --spacing-sections-mobile: {% if settings.spacing_sections < 24 %}{{ settings.spacing_sections }}{% else %}{{ settings.spacing_sections | times: 0.7 | round | at_least: 20 }}{% endif %}px;
 
-                  --grid-desktop-vertical-spacing: {{ settings.spacing_grid_vertical }}px;
-                  --grid-desktop-horizontal-spacing: {{ settings.spacing_grid_horizontal }}px;
-                  --grid-mobile-vertical-spacing: {{ settings.spacing_grid_vertical | divided_by: 2 }}px;
-                  --grid-mobile-horizontal-spacing: {{ settings.spacing_grid_horizontal | divided_by: 2 }}px;
+        --grid-desktop-vertical-spacing: {{ settings.spacing_grid_vertical }}px;
+        --grid-desktop-horizontal-spacing: {{ settings.spacing_grid_horizontal }}px;
+        --grid-mobile-vertical-spacing: {{ settings.spacing_grid_vertical | divided_by: 2 }}px;
+        --grid-mobile-horizontal-spacing: {{ settings.spacing_grid_horizontal | divided_by: 2 }}px;
 
-                  --text-boxes-border-opacity: {{ settings.text_boxes_border_opacity | divided_by: 100.0 }};
-                  --text-boxes-border-width: {{ settings.text_boxes_border_thickness }}px;
-                  --text-boxes-radius: {{ settings.text_boxes_radius }}px;
-                  --text-boxes-shadow-opacity: {{ settings.text_boxes_shadow_opacity | divided_by: 100.0 }};
-                  --text-boxes-shadow-visible: {% if settings.text_boxes_shadow_opacity > 0 %}1{% else %}0{% endif %};
-                  --text-boxes-shadow-horizontal-offset: {{ settings.text_boxes_shadow_horizontal_offset }}px;
-                  --text-boxes-shadow-vertical-offset: {{ settings.text_boxes_shadow_vertical_offset }}px;
-                  --text-boxes-shadow-blur-radius: {{ settings.text_boxes_shadow_blur }}px;
+        --text-boxes-border-opacity: {{ settings.text_boxes_border_opacity | divided_by: 100.0 }};
+        --text-boxes-border-width: {{ settings.text_boxes_border_thickness }}px;
+        --text-boxes-radius: {{ settings.text_boxes_radius }}px;
+        --text-boxes-shadow-opacity: {{ settings.text_boxes_shadow_opacity | divided_by: 100.0 }};
+        --text-boxes-shadow-visible: {% if settings.text_boxes_shadow_opacity > 0 %}1{% else %}0{% endif %};
+        --text-boxes-shadow-horizontal-offset: {{ settings.text_boxes_shadow_horizontal_offset }}px;
+        --text-boxes-shadow-vertical-offset: {{ settings.text_boxes_shadow_vertical_offset }}px;
+        --text-boxes-shadow-blur-radius: {{ settings.text_boxes_shadow_blur }}px;
 
-                  --buttons-radius: {{ settings.buttons_radius }}px;
-                  --buttons-radius-outset: {% if settings.buttons_radius > 0 %}{{ settings.buttons_radius | plus: settings.buttons_border_thickness }}{% else %}0{% endif %}px;
-                  --buttons-border-width: {% if settings.buttons_border_opacity > 0 %}{{ settings.buttons_border_thickness }}{% else %}0{% endif %}px;
-                  --buttons-border-opacity: {{ settings.buttons_border_opacity | divided_by: 100.0 }};
-                  --buttons-shadow-opacity: {{ settings.buttons_shadow_opacity | divided_by: 100.0 }};
-                  --buttons-shadow-visible: {% if settings.buttons_shadow_opacity > 0 %}1{% else %}0{% endif %};
-                  --buttons-shadow-horizontal-offset: {{ settings.buttons_shadow_horizontal_offset }}px;
-                  --buttons-shadow-vertical-offset: {{ settings.buttons_shadow_vertical_offset }}px;
-                  --buttons-shadow-blur-radius: {{ settings.buttons_shadow_blur }}px;
-                  --buttons-border-offset: {% if settings.buttons_radius > 0 or settings.buttons_shadow_opacity > 0 %}0.3{% else %}0{% endif %}px;
+        --buttons-radius: {{ settings.buttons_radius }}px;
+        --buttons-radius-outset: {% if settings.buttons_radius > 0 %}{{ settings.buttons_radius | plus: settings.buttons_border_thickness }}{% else %}0{% endif %}px;
+        --buttons-border-width: {% if settings.buttons_border_opacity > 0 %}{{ settings.buttons_border_thickness }}{% else %}0{% endif %}px;
+        --buttons-border-opacity: {{ settings.buttons_border_opacity | divided_by: 100.0 }};
+        --buttons-shadow-opacity: {{ settings.buttons_shadow_opacity | divided_by: 100.0 }};
+        --buttons-shadow-visible: {% if settings.buttons_shadow_opacity > 0 %}1{% else %}0{% endif %};
+        --buttons-shadow-horizontal-offset: {{ settings.buttons_shadow_horizontal_offset }}px;
+        --buttons-shadow-vertical-offset: {{ settings.buttons_shadow_vertical_offset }}px;
+        --buttons-shadow-blur-radius: {{ settings.buttons_shadow_blur }}px;
+        --buttons-border-offset: {% if settings.buttons_radius > 0 or settings.buttons_shadow_opacity > 0 %}0.3{% else %}0{% endif %}px;
 
-                  --inputs-radius: {{ settings.inputs_radius }}px;
-                  --inputs-border-width: {{ settings.inputs_border_thickness }}px;
-                  --inputs-border-opacity: {{ settings.inputs_border_opacity | divided_by: 100.0 }};
-                  --inputs-shadow-opacity: {{ settings.inputs_shadow_opacity | divided_by: 100.0 }};
-                  --inputs-shadow-horizontal-offset: {{ settings.inputs_shadow_horizontal_offset }}px;
-                  --inputs-margin-offset: {% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_opacity > 0 %}{{ settings.inputs_shadow_vertical_offset | abs }}{% else %}0{% endif %}px;
-                  --inputs-shadow-vertical-offset: {{ settings.inputs_shadow_vertical_offset }}px;
-                  --inputs-shadow-blur-radius: {{ settings.inputs_shadow_blur }}px;
-                  --inputs-radius-outset: {% if settings.inputs_radius > 0 %}{{ settings.inputs_radius | plus: settings.inputs_border_thickness }}{% else %}0{% endif %}px;
+        --inputs-radius: {{ settings.inputs_radius }}px;
+        --inputs-border-width: {{ settings.inputs_border_thickness }}px;
+        --inputs-border-opacity: {{ settings.inputs_border_opacity | divided_by: 100.0 }};
+        --inputs-shadow-opacity: {{ settings.inputs_shadow_opacity | divided_by: 100.0 }};
+        --inputs-shadow-horizontal-offset: {{ settings.inputs_shadow_horizontal_offset }}px;
+        --inputs-margin-offset: {% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_opacity > 0 %}{{ settings.inputs_shadow_vertical_offset | abs }}{% else %}0{% endif %}px;
+        --inputs-shadow-vertical-offset: {{ settings.inputs_shadow_vertical_offset }}px;
+        --inputs-shadow-blur-radius: {{ settings.inputs_shadow_blur }}px;
+        --inputs-radius-outset: {% if settings.inputs_radius > 0 %}{{ settings.inputs_radius | plus: settings.inputs_border_thickness }}{% else %}0{% endif %}px;
 
-                  --variant-pills-radius: {{ settings.variant_pills_radius }}px;
-                  --variant-pills-border-width: {{ settings.variant_pills_border_thickness }}px;
-                  --variant-pills-border-opacity: {{ settings.variant_pills_border_opacity | divided_by: 100.0 }};
-                  --variant-pills-shadow-opacity: {{ settings.variant_pills_shadow_opacity | divided_by: 100.0 }};
-                  --variant-pills-shadow-horizontal-offset: {{ settings.variant_pills_shadow_horizontal_offset }}px;
-                  --variant-pills-shadow-vertical-offset: {{ settings.variant_pills_shadow_vertical_offset }}px;
-                  --variant-pills-shadow-blur-radius: {{ settings.variant_pills_shadow_blur }}px;
-                }
+        --variant-pills-radius: {{ settings.variant_pills_radius }}px;
+        --variant-pills-border-width: {{ settings.variant_pills_border_thickness }}px;
+        --variant-pills-border-opacity: {{ settings.variant_pills_border_opacity | divided_by: 100.0 }};
+        --variant-pills-shadow-opacity: {{ settings.variant_pills_shadow_opacity | divided_by: 100.0 }};
+        --variant-pills-shadow-horizontal-offset: {{ settings.variant_pills_shadow_horizontal_offset }}px;
+        --variant-pills-shadow-vertical-offset: {{ settings.variant_pills_shadow_vertical_offset }}px;
+        --variant-pills-shadow-blur-radius: {{ settings.variant_pills_shadow_blur }}px;
+      }
 
-                *,
-                *::before,
-                *::after {
-                  box-sizing: inherit;
-                }
+      *,
+      *::before,
+      *::after {
+        box-sizing: inherit;
+      }
 
-                html {
-                  box-sizing: border-box;
-                  font-size: calc(var(--font-body-scale));
-                  height: 100%;
-                }
+      html {
+        box-sizing: border-box;
+        font-size: calc(var(--font-body-scale));
+        height: 100%;
+      }
 
-                body {
-                  display: grid;
-                  grid-template-rows: auto auto auto auto 1fr auto;
-                  grid-template-columns: 100%;
-                  min-height: 100%;
-                  margin: 0;
-                  font-size: 0.875rem;
-                  letter-spacing: 0rem;
-                  line-height: calc(1 + 0.8 / var(--font-body-scale));
-                  font-family: var(--font-body-family);
-                  font-style: var(--font-body-style);
-                  font-weight: var(--font-body-weight);
-                }
+      body {
+        display: grid;
+        grid-template-rows: auto auto auto auto 1fr auto;
+        grid-template-columns: 100%;
+        min-height: 100%;
+        margin: 0;
+        font-size: 0.875rem;
+        letter-spacing: 0rem;
+        line-height: calc(1 + 0.8 / var(--font-body-scale));
+        font-family: var(--font-body-family);
+        font-style: var(--font-body-style);
+        font-weight: var(--font-body-weight);
+      }
 
-                @media screen and (min-width: 750px) {
-                  body {
-                    font-size: 1rem;
-                  }
-                }
+      @media screen and (min-width: 750px) {
+        body {
+          font-size: 1rem;
+        }
+      }
 
-                input[type="checkbox"]:checked:after {
-                  position: absolute;
-                  top: 0;
-                  left: 0;
-                  transform: scale(0.7);
-                  width: 100%;
-                  height: 100%;
-                  background: #fff;
-                  content: '';
-                  -webkit-mask: url({{ 'icon-checkmark.svg' | asset_url }}) no-repeat 50% 50%;
-                  mask: url({{ 'icon-checkmark.svg' | asset_url }}) no-repeat 50% 50%;
-                  -webkit-mask-size: cover;
-                  mask-size: cover;
-                }
+      input[type="checkbox"]:checked:after {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transform: scale(0.7);
+        width: 100%;
+        height: 100%;
+        background: #fff;
+        content: '';
+        -webkit-mask: url({{ 'icon-checkmark.svg' | asset_url }}) no-repeat 50% 50%;
+        mask: url({{ 'icon-checkmark.svg' | asset_url }}) no-repeat 50% 50%;
+        -webkit-mask-size: cover;
+        mask-size: cover;
+      }
     {% endstyle %}
 
     {%- comment -%} Critical CSS inlined for performance {%- endcomment -%}
     {{ 'critical.css' | asset_url | stylesheet_tag }}
 
     {%- comment -%} Preload critical stylesheets {%- endcomment -%}
-    <link rel="preload" href="{{ 'application.css' | asset_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link
+      rel="preload"
+      href="{{ 'application.css' | asset_url }}"
+      as="style"
+      onload="this.onload=null;this.rel='stylesheet'"
+    >
     <link rel="preload" href="{{ 'base.css' | asset_url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
 
     {%- comment -%} Non-critical CSS loaded asynchronously {%- endcomment -%}
@@ -323,7 +332,10 @@
     {%- endif -%}
 
     {%- comment -%} Conditional CSS loading for phone input (only when needed) {%- endcomment -%}
-    {%- if template.name == 'customers/register' or template.name == 'customers/account' or template.name == 'customers/addresses' -%}
+    {%- if template.name == 'customers/register'
+      or template.name == 'customers/account'
+      or template.name == 'customers/addresses'
+    -%}
       <link rel="stylesheet" href="{{ 'intl-tel-input.min.css' | asset_url }}" media="print" onload="this.media='all'">
       <link rel="stylesheet" href="{{ 'phone-input.css' | asset_url }}" media="print" onload="this.media='all'">
     {%- endif -%}
@@ -337,7 +349,10 @@
       {%- if shop.customer_accounts_enabled -%}
         {{ 'user-menu-popup.css' | asset_url | stylesheet_tag }}
       {%- endif -%}
-      {%- if template.name == 'customers/register' or template.name == 'customers/account' or template.name == 'customers/addresses' -%}
+      {%- if template.name == 'customers/register'
+        or template.name == 'customers/account'
+        or template.name == 'customers/addresses'
+      -%}
         {{ 'intl-tel-input.min.css' | asset_url | stylesheet_tag }}
         {{ 'phone-input.css' | asset_url | stylesheet_tag }}
       {%- endif -%}
@@ -382,8 +397,9 @@
         document.documentElement.classList.add('shopify-design-mode');
       }
     </script>
-  {% include 'pagefly-app-header' %}{% render 'google_consent_mode_script' %}
-</head>
+    {% include 'pagefly-app-header' %}
+    {% render 'google_consent_mode_script' %}
+  </head>
 
   <body class="gradient{% if settings.animations_hover_elements != 'none' %} animate--hover-{{ settings.animations_hover_elements }}{% endif %} template-{{ template.name | handle }}{% if request.page_type == 'page' and request.path contains '/pages/wishlist' %} page-wishlist{% endif %}">
     <a class="skip-to-content-link button visually-hidden" href="#MainContent">
@@ -534,7 +550,7 @@
           articles: `{{ 'templates.search.articles' | t | escape }}`,
           products: `{{ 'templates.search.products' | t | escape }}`,
           no_results: `{{ 'templates.search.no_results' | t | escape }}`,
-          no_results_suggestion: `{{ 'templates.search.no_results_suggestion' | t | escape }}`
+          no_results_suggestion: `{{ 'templates.search.no_results_suggestion' | t | escape }}`,
         };
       </script>
       <script src="{{ 'predictive-search.js' | asset_url }}" defer="defer"></script>
@@ -544,13 +560,18 @@
       <script src="{{ 'cart-drawer.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
 
-    <script>window.initialCartData = {{ cart | json }};</script>
+    <script>
+      window.initialCartData = {{ cart | json }};
+    </script>
     <script src="{{ 'cart-sync.js' | asset_url }}" defer="defer"></script>
 
     <script src="{{ 'product-utils.module.js' | asset_url }}" type="module"></script>
 
     {% comment %} International Phone Input - Load only when needed {% endcomment %}
-    {%- if template.name == 'customers/register' or template.name == 'customers/account' or template.name == 'customers/addresses' -%}
+    {%- if template.name == 'customers/register'
+      or template.name == 'customers/account'
+      or template.name == 'customers/addresses'
+    -%}
       <script src="{{ 'intl-tel-input.min.js' | asset_url }}" defer></script>
       <script src="{{ 'intl-tel-input-utils.js' | asset_url }}" defer></script>
       <script src="{{ 'phone-validation.js' | asset_url }}" defer></script>
@@ -621,5 +642,6 @@
         {% endif %}
       });
     </script>
-  {%- render "ecom_footer"-%}</body>
+    {%- render 'ecom_footer' -%}
+  </body>
 </html>

--- a/layout/theme.pagefly.liquid
+++ b/layout/theme.pagefly.liquid
@@ -37,7 +37,7 @@ If you plan to remove PageFly, please see the guide in our help center first: ht
         {%- endif -%}
       {%- endfor -%}
     {%- elsif template.name == 'product' and product.featured_image -%}
-      <link rel="preload" as="image" href="{{ product.featured_image | image_url: width: 800 }}">
+      <link rel="preload" as="image" href="{{ product.selected_or_first_available_variant.featured_media.preview_image | default: product.selected_or_first_available_variant.featured_image | default: product.featured_image | image_url: width: 800 }}">
     {%- endif -%}
 
     <title>

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -555,6 +555,13 @@
     assign active_color_data_attr = active_color_value
   endif
 
+  # Keep the server-rendered candidate stable through hydration. The runtime
+  # receives this ID and uses it as the initial item in the same sequence.
+  assign initial_media = first_variant.featured_media | default: product.featured_media | default: product.media.first
+  assign initial_image = initial_media.preview_image | default: initial_media
+  assign initial_media_id = initial_media.id | default: ''
+  assign initial_media_ratio = initial_image.aspect_ratio | default: 1
+
   # Initialize media string with all media URLs
   assign all_media = ''
   for media in product.media
@@ -579,10 +586,11 @@
   data-desktop-layout="{{ section.settings.gallery_layout }}"
   data-active-color="{{ active_color_data_attr }}"
   data-section-id="{{ section.id }}"
+  data-initial-media-id="{{ initial_media_id }}"
   class="relative"
 >
   <div id="GalleryStatus-{{ section.id }}" class="visually-hidden" role="status"></div>
-  <div class="swiper product-swiper loading-media md:hidden" data-gallery-mobile>
+  <div class="swiper product-swiper md:hidden" data-gallery-mobile>
     <a class="skip-to-content-link button visually-hidden quick-add-hidden" href="#ProductInfo-{{ section.id }}">
       {{ 'accessibility.skip_to_product_info' | t }}
     </a>
@@ -596,9 +604,46 @@
       data-active-color="{{ active_color_data_attr }}"
       aria-live="polite"
     >
-      {%- if product.media.size == 0 -%}
+      {%- if initial_image != blank -%}
+        <div
+          class="swiper-slide product__media-item is-active"
+          data-gallery-item
+          data-gallery-media-id="{{ initial_media_id }}"
+          data-media-id="{{ initial_media_id }}"
+          data-media-type="{{ initial_media.media_type | default: 'image' }}"
+        >
+          <div
+            class="product__media media relative h-0 w-full"
+            style="--ratio: {{ initial_media_ratio }}; --preview-ratio: {{ initial_media_ratio }}; aspect-ratio: {{ initial_media_ratio }};"
+          >
+            <div class="absolute inset-0 h-full w-full">
+              <img
+                src="{{ initial_image | image_url: width: 800 }}"
+                srcset="
+                  {{ initial_image | image_url: width: 360 }} 360w,
+                  {{ initial_image | image_url: width: 540 }} 540w,
+                  {{ initial_image | image_url: width: 720 }} 720w,
+                  {{ initial_image | image_url: width: 900 }} 900w,
+                  {{ initial_image | image_url: width: 1080 }} 1080w,
+                  {{ initial_image | image_url: width: 1296 }} 1296w,
+                  {{ initial_image | image_url: width: 1512 }} 1512w,
+                  {{ initial_image | image_url: width: 1800 }} 1800w
+                "
+                sizes="(min-width: 990px) 66vw, 100vw"
+                alt="{{ initial_image.alt | default: product.title | escape }}"
+                width="{{ initial_image.width | default: 800 }}"
+                height="{{ initial_image.height | default: 800 }}"
+                loading="eager"
+                fetchpriority="high"
+                decoding="async"
+                class="media-item product-lightbox-img h-full w-full object-cover"
+              >
+            </div>
+          </div>
+        </div>
+      {%- else -%}
         {%- comment -%} Fallback placeholder for mobile when no media and JS fails {%- endcomment -%}
-        <div class="swiper-slide product__media-item is-active scroll-trigger animate--fade-in">
+        <div class="swiper-slide product__media-item is-active" data-gallery-item data-gallery-media-id="placeholder">
           <div
             class="product__media media relative h-0 w-full"
             style="--ratio: 1.0; --preview-ratio: 1.0; padding-bottom: 100%;"
@@ -613,15 +658,62 @@
     <div class="swiper-pagination"></div>
   </div>
 
-  <div id="desktop-gallery" data-gallery-grid class="loading-media relative hidden grid-cols-2 gap-4 md:grid">
-    {%- comment -%} Desktop gallery content will be rendered entirely by JavaScript {%- endcomment -%}
-    {%- comment -%} This eliminates server-side vs client-side sorting conflicts {%- endcomment -%}
-    <div id="desktop-gallery-loading" class="col-span-2 flex items-center justify-center py-8">
-      <div class="text-center">
-        <div class="mb-2 inline-block h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900"></div>
-        <p class="text-sm text-gray-600">Loading gallery...</p>
+  <div id="desktop-gallery" data-gallery-grid class="relative hidden grid-cols-2 gap-4 md:grid">
+    {%- if initial_image != blank -%}
+      <div
+        class="swiper-slide product__media-item is-active"
+        data-gallery-item
+        data-gallery-media-id="{{ initial_media_id }}"
+        data-media-id="{{ initial_media_id }}"
+        data-media-type="{{ initial_media.media_type | default: 'image' }}"
+      >
+        <div
+          class="product__media media relative h-0 w-full"
+          style="--ratio: {{ initial_media_ratio }}; --preview-ratio: {{ initial_media_ratio }}; aspect-ratio: {{ initial_media_ratio }};"
+        >
+          <div class="absolute inset-0 h-full w-full">
+            <img
+              src="{{ initial_image | image_url: width: 800 }}"
+              srcset="
+                {{ initial_image | image_url: width: 360 }} 360w,
+                {{ initial_image | image_url: width: 540 }} 540w,
+                {{ initial_image | image_url: width: 720 }} 720w,
+                {{ initial_image | image_url: width: 900 }} 900w,
+                {{ initial_image | image_url: width: 1080 }} 1080w,
+                {{ initial_image | image_url: width: 1296 }} 1296w,
+                {{ initial_image | image_url: width: 1512 }} 1512w,
+                {{ initial_image | image_url: width: 1800 }} 1800w
+              "
+              sizes="(min-width: 990px) 66vw, 100vw"
+              alt="{{ initial_image.alt | default: product.title | escape }}"
+              width="{{ initial_image.width | default: 800 }}"
+              height="{{ initial_image.height | default: 800 }}"
+              loading="eager"
+              fetchpriority="high"
+              decoding="async"
+              class="media-item product-lightbox-img h-full w-full object-cover"
+            >
+          </div>
+        </div>
       </div>
-    </div>
+    {%- else -%}
+      <div
+        class="swiper-slide product__media-item is-active"
+        data-gallery-item
+        data-gallery-media-id="placeholder"
+        data-media-id="placeholder"
+        data-media-type="placeholder"
+      >
+        <div
+          class="product__media media relative h-0 w-full"
+          style="--ratio: 1; --preview-ratio: 1; aspect-ratio: 1; padding-bottom: 100%;"
+        >
+          <div class="absolute inset-0 flex h-full w-full items-center justify-center bg-gray-100">
+            {{ 'product-apparel-2' | placeholder_svg_tag: 'h-full w-full max-h-[60%] max-w-[60%] text-gray-400' }}
+          </div>
+        </div>
+      </div>
+    {%- endif -%}
   </div>
 
   <!-- See More/Less Button -->
@@ -639,6 +731,7 @@
     {
       "colorOptionIndex": {{ color_option_index }},
       "colorValueToReferenceId": {{ color_value_to_ref_json }},
+      "productTitle": {{ product.title | json }},
       "moreImagesText": {{ 'sections.main_product.more_images' | t | json }},
       "lessImagesText": {{ 'sections.main_product.less_images' | t | json }}
     }

--- a/tests/product-media-gallery-runtime-source.test.js
+++ b/tests/product-media-gallery-runtime-source.test.js
@@ -6,6 +6,7 @@ const readProjectFile = (path) => readFileSync(fileURLToPath(new URL(`../${path}
 
 describe("product media gallery runtime", () => {
   const runtime = readProjectFile("assets/product-media-gallery-runtime.js");
+  const sequence = readProjectFile("assets/product-media-gallery-sequence.js");
   const mediaGallery = readProjectFile("assets/media-gallery.js");
   const snippet = readProjectFile("snippets/product-media-gallery.liquid");
 
@@ -17,6 +18,11 @@ describe("product media gallery runtime", () => {
     expect(runtime).toContain("class ProductMediaGalleryController");
     expect(runtime).toContain("const controllers = new Map()");
     expect(runtime).toContain("this.root.querySelector");
+    expect(runtime).toContain("resolveProductMediaSequence");
+    expect(runtime).not.toContain("cloneNode");
+    expect(runtime).not.toContain("replaceChildren");
+    expect(runtime).toContain("preserveFirstImage");
+    expect(runtime).toContain("mediaItem.dataset.galleryHydrated");
   });
 
   test("uses the canonical variant pub/sub event exactly once per gallery", () => {
@@ -48,5 +54,35 @@ describe("product media gallery runtime", () => {
     expect(mediaGallery).toContain('this.querySelector(`[data-media-id="${mediaId}"]`)');
     expect(mediaGallery).toContain('this.querySelectorAll("[data-media-id]")');
     expect(mediaGallery).not.toContain('document.querySelector(`[data-media-id="${mediaId}"]`)');
+  });
+
+  test("shares one deterministic sequence contract between SSR and hydration", () => {
+    expect(sequence).toContain("export function resolveProductMediaSequence");
+    expect(sequence).toContain("filterMediaByColor");
+    expect(sequence).toContain("sortImagesByDisplayRules");
+    expect(sequence).toContain("hidden: index >= visibleCount");
+    expect(snippet).toContain("data-initial-media-id");
+    expect(snippet).toContain('loading="eager"');
+    expect(snippet).toContain('fetchpriority="high"');
+    expect(snippet).toContain("srcset=");
+    expect(snippet).toContain('sizes="(min-width: 990px) 66vw, 100vw"');
+  });
+
+  test("keeps the meaningful SSR fallback visible and aligns the image preload", () => {
+    expect(snippet).toContain("data-gallery-item");
+    expect(snippet).not.toContain("Loading gallery...");
+    expect(snippet).not.toContain('class="swiper product-swiper loading-media');
+    const alignedPreload =
+      "product.selected_or_first_available_variant.featured_media.preview_image | default: product.selected_or_first_available_variant.featured_image | default: product.featured_image | image_url: width: 800";
+    expect(readProjectFile("layout/theme.liquid")).toContain(alignedPreload);
+    expect(readProjectFile("layout/theme.pagefly.liquid")).toContain(alignedPreload);
+  });
+
+  test("does not use global gallery selectors or state", () => {
+    expect(runtime).not.toContain("document.querySelector(");
+    expect(runtime).not.toContain("window.slidesToCreate");
+    expect(runtime).not.toContain("window.productSwiper");
+    expect(runtime).not.toContain("window.isGalleryExpanded");
+    expect(runtime).not.toContain("window.ProductMediaGalleryController");
   });
 });

--- a/tests/product-media-gallery-sequence.test.js
+++ b/tests/product-media-gallery-sequence.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+import { resolveProductMediaSequence } from "../assets/product-media-gallery-sequence.js";
+
+const image = (id, filename, overrides = {}) => ({
+  id,
+  media_type: "image",
+  src: `https://cdn.shopify.com/${filename}`,
+  width: 1200,
+  height: 1200,
+  alt: `Image ${id}`,
+  ...overrides,
+});
+
+const video = (id, filename, overrides = {}) => ({
+  id,
+  media_type: "video",
+  preview_image: {
+    src: `https://cdn.shopify.com/${filename}`,
+    width: 1200,
+    height: 1200,
+  },
+  sources: [{ url: `https://cdn.shopify.com/${id}.mp4`, mime_type: "video/mp4" }],
+  ...overrides,
+});
+
+const baseMedia = [
+  image("main", "coat--NF-no-5009snw-darkblue-H.jpg"),
+  image("model", "coat--NF-no-5009snw-darkblue-M_1.jpg"),
+  image("detail", "coat--NF-no-5009snw-darkblue-D_1.jpg"),
+  video("video", "coat--NF-no-5009snw-darkblue-BV.jpg"),
+  image("other-color", "coat--NF-no-5009snw-red-H.jpg"),
+];
+
+describe("resolveProductMediaSequence", () => {
+  test.each([
+    ["zero media", [], "", [], []],
+    ["one image", [image("one", "one--NF-no-1-black-H.jpg")], "", ["one"], [false]],
+    [
+      "sorted image and video sequence",
+      baseMedia,
+      "",
+      ["main", "video", "model", "detail", "other-color"],
+      [false, false, false, false, false],
+    ],
+    [
+      "six visible and remaining hidden",
+      [
+        ...baseMedia,
+        image("detail-2", "coat--NF-no-5009snw-darkblue-D_2.jpg"),
+        image("detail-3", "coat--NF-no-5009snw-darkblue-D_3.jpg"),
+      ],
+      "",
+      ["main", "video", "model", "detail", "detail-2", "detail-3", "other-color"],
+      [false, false, false, false, false, false, true],
+    ],
+  ])("%s", (_, media, activeColor, ids, hidden) => {
+    const resolved = resolveProductMediaSequence({ media, activeColor });
+    expect(resolved.map((item) => item.mediaId)).toEqual(ids);
+    expect(resolved.map((item) => item.hidden)).toEqual(hidden);
+    expect(resolved.every((item) => item.media === media.find((source) => source.id === item.mediaId))).toBe(true);
+  });
+
+  test("keeps exact color filtering and reference-id mappings", () => {
+    const media = [
+      image("blue", "coat--NF-no-5009snw-42-H.jpg"),
+      image("red", "coat--NF-no-5009snw-99-H.jpg"),
+      image("fallback", "coat--NF-no-5009snw-green-H.jpg"),
+    ];
+    const colorMappings = [
+      { reference_id: 42, name: "darkblue" },
+      { reference_id: 99, name: "red" },
+    ];
+
+    expect(
+      resolveProductMediaSequence({ media, activeColor: "42", colorMappings }).map((item) => item.mediaId),
+    ).toEqual(["blue"]);
+  });
+
+  test("moves the server candidate to the authoritative first position", () => {
+    const resolved = resolveProductMediaSequence({
+      media: baseMedia,
+      initialMediaId: "model",
+    });
+
+    expect(resolved[0].mediaId).toBe("model");
+    expect(resolved.slice(1).map((item) => item.mediaId)).toEqual(["main", "video", "detail", "other-color"]);
+  });
+
+  test.each(["model", "external_video"])("retains non-image media objects: %s", (mediaType) => {
+    const special =
+      mediaType === "model"
+        ? { id: "model", media_type: "model", preview_image: { src: "https://cdn/model.jpg" }, sources: [] }
+        : { id: "external", media_type: "external_video", preview_image: { src: "https://cdn/ext.jpg" } };
+    const resolved = resolveProductMediaSequence({ media: [special] });
+
+    expect(resolved[0].media).toBe(special);
+    expect(resolved[0].mediaType).toBe(mediaType);
+  });
+});


### PR DESCRIPTION
## Summary

- add a pure deterministic media-sequence resolver with table-driven coverage for color/reference matching, fallback ordering, media types, and display rules
- server-render the authoritative initial product media in a stable intrinsic-ratio box
- emit responsive Shopify image candidates with `sizes`, eager loading, and high fetch priority
- hydrate the existing SSR image instead of clearing and recreating it
- align the product preload to the same initial media candidate and retain a meaningful no-JavaScript fallback
- preserve the section-scoped lifecycle established by #70

## Stack

- Depends on #69 and #70
- **This PR**, stack 3/4
- Next: #66 safe asset cleanup

Review this PR against base `perf/63-gallery-runtime` so the diff contains only issue #62.

## Validation

- focused gallery sequence/runtime tests passed, 16 tests
- `pnpm validate` passed, 54 tests at this stack level
- `pnpm lint` passed, including Prettier and Theme Check
- Theme Check has 189 pre-existing warnings and no errors
- `git diff --check` passed and the worktree is clean
- full stack validation later passed 59 tests

## Known assumptions and required preview verification

No Shopify theme was pushed or deployed. An unpublished duplicate theme is still required to prove:

- selected/default variant SSR media matches the hydrated sequence on real products
- initial HTML has nonzero stable geometry before JavaScript
- preload and rendered candidate do not double-fetch
- mobile/desktop instances, one/many/no-media products, videos, models, external videos, Fancybox, Swiper, variant switching, and back/forward flows remain correct
- Main/BG/SK median cold-load CLS/LCP improvements and layout-shift attribution

Closes #62
