### PR TITLE
perf(product-gallery): serve responsive srcset for JS-rendered images (#74)

### DIFF
--- a/assets/product-media-gallery-runtime.js
+++ b/assets/product-media-gallery-runtime.js
@@ -305,7 +305,11 @@
         imageElement = document.createElement("img");
         this.setContent(content, imageElement);
       }
-      if (!preserveFirstImage) imageElement.src = image.src;
+      if (!preserveFirstImage) {
+        imageElement.src = this.buildImageUrl(image.src, 800);
+        imageElement.srcset = this.buildImageSrcset(image.src);
+        imageElement.sizes = "(min-width: 990px) 66vw, 100vw";
+      }
       imageElement.alt = image.alt || this.data.options.productTitle || "Product image";
       imageElement.className = "media-item w-full h-full object-cover product-lightbox-img";
       imageElement.loading = index === 0 ? "eager" : "lazy";
@@ -317,6 +321,18 @@
         event.preventDefault();
         this.openLightbox(index);
       };
+    }
+
+    buildImageUrl(src, width) {
+      if (!src) return src;
+      const separator = src.includes("?") ? "&" : "?";
+      return `${src}${separator}width=${width}`;
+    }
+
+    buildImageSrcset(src) {
+      if (!src) return "";
+      const widths = [360, 540, 720, 900, 1080, 1296, 1512, 1800];
+      return widths.map((width) => `${this.buildImageUrl(src, width)} ${width}w`).join(", ");
     }
 
     setContent(container, content) {

--- a/tests/product-media-gallery-runtime-source.test.js
+++ b/tests/product-media-gallery-runtime-source.test.js
@@ -92,4 +92,11 @@ describe("product media gallery runtime", () => {
     expect(galleryCss).toContain(".product-swiper[data-gallery-mobile] .swiper-wrapper");
     expect(galleryCss).toContain("aspect-ratio: var(--gallery-initial-ratio, 1)");
   });
+
+  test("serves responsive srcset for JS-rendered gallery images", () => {
+    expect(runtime).toContain("buildImageSrcset");
+    expect(runtime).toContain("imageElement.srcset = this.buildImageSrcset(image.src)");
+    expect(runtime).toContain('imageElement.sizes = "(min-width: 990px) 66vw, 100vw"');
+    expect(runtime).not.toContain("if (!preserveFirstImage) imageElement.src = image.src;");
+  });
 });


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>