### PR TITLE
fix(product-media): pick front-first images on cards and PDP

### DIFF
--- a/assets/product-media-gallery-sequence.js
+++ b/assets/product-media-gallery-sequence.js
@@ -1,4 +1,4 @@
-import { filterMediaByColor, sortImagesByDisplayRules } from "./product-utils.module.js";
+import { filterMediaByColor, parseImageUrl, sortImagesByDisplayRules } from "./product-utils.module.js";
 
 const VISIBLE_MEDIA_COUNT = 6;
 
@@ -106,7 +106,12 @@ export function resolveProductMediaSequence({
   if (initialMediaId !== null && initialMediaId !== undefined && sequence.length > 1) {
     const initialIndex = sequence.findIndex((item) => String(item.mediaId) === String(initialMediaId));
     if (initialIndex > 0) {
-      sequence = [sequence[initialIndex], ...sequence.slice(0, initialIndex), ...sequence.slice(initialIndex + 1)];
+      const parsed = parseImageUrl(sequence[initialIndex].source);
+      const isBackType = parsed.image_type === "back_variant" || parsed.image_type === "back_main";
+
+      if (!isBackType) {
+        sequence = [sequence[initialIndex], ...sequence.slice(0, initialIndex), ...sequence.slice(initialIndex + 1)];
+      }
     }
   }
 

--- a/assets/product-utils.module.js
+++ b/assets/product-utils.module.js
@@ -14,17 +14,28 @@ const SHOPIFY_UUID_SUFFIX_PATTERN = /_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-
 const parseCache = new Map();
 const MAX_CACHE_SIZE = 1000;
 
-// Priority lookup table - avoids function call overhead in sorting
-const PRIORITY_MAP = {
-  main: { no_seq: 1, with_seq: (seq) => 1 + seq * 0.1 },
-  back_variant: 2,
-  back_main: { fallback: 2, normal: 11 },
-  model: { seq_1: 3, seq_n: (seq) => 3 + seq },
-  video: 12,
-  details: { seq_1: 13, seq_n: (seq) => 13 + seq, no_seq: 20 },
-  other_model: 21,
-  default: 100
+// Front-first display order, shared by PDP gallery and product cards:
+// H → M → M_N → D_N → BV → B
+const displayPriority = (img) => {
+  switch (img.image_type) {
+    case "main":
+      return img.sequence ? 1 + img.sequence * 0.1 : 1;
+    case "model":
+      return img.sequence > 0 ? 2 + img.sequence : 2;
+    case "video":
+      return 12;
+    case "details":
+      return img.sequence > 0 ? 13 + img.sequence : 20;
+    case "back_variant":
+      return 30;
+    case "back_main":
+      return 31;
+    default:
+      return 100;
+  }
 };
+
+export { displayPriority };
 
 /**
  * Parses an image/video URL according to the nomenclature rules
@@ -290,33 +301,13 @@ export function sortImagesByDisplayRules(imageUrls, colorMappings = null) {
   // Sort each group according to the new display rules
   Object.keys(groupedImages).forEach((key) => {
     const group = groupedImages[key];
-    
-    // First, check if we have a BV (back variant) image in this group
-    let hasBV = false;
-    for (let i = 0; i < group.length; i++) {
-      if (group[i].image_type === "back_variant") { hasBV = true; break; }
-    }
 
     group.sort((a, b) => {
-      // Inline priority calculation to avoid function call overhead
-      let pa = a.image_type === "main" ? (a.sequence ? 1 + a.sequence * 0.1 : 1) :
-                a.image_type === "back_variant" ? 2 :
-                a.image_type === "back_main" ? (hasBV ? 11 : 2) :
-                a.image_type === "model" ? (a.sequence === 1 ? 3 : a.sequence > 1 ? 3 + a.sequence : 21) :
-                a.image_type === "video" ? 12 :
-                a.image_type === "details" ? (a.sequence === 1 ? 13 : a.sequence > 1 ? 13 + a.sequence : 20) : 100;
-      
-      let pb = b.image_type === "main" ? (b.sequence ? 1 + b.sequence * 0.1 : 1) :
-                b.image_type === "back_variant" ? 2 :
-                b.image_type === "back_main" ? (hasBV ? 11 : 2) :
-                b.image_type === "model" ? (b.sequence === 1 ? 3 : b.sequence > 1 ? 3 + b.sequence : 21) :
-                b.image_type === "video" ? 12 :
-                b.image_type === "details" ? (b.sequence === 1 ? 13 : b.sequence > 1 ? 13 + b.sequence : 20) : 100;
+      const pa = displayPriority(a);
+      const pb = displayPriority(b);
 
-      // If priorities differ, return immediately (avoids string comparison in most cases)
       if (pa !== pb) return pa - pb;
 
-      // Only do string comparison when priorities are equal
       return a.unique_id < b.unique_id ? -1 : a.unique_id > b.unique_id ? 1 : 0;
     });
 
@@ -407,7 +398,7 @@ export function sortImagesByDisplayRules(imageUrls, colorMappings = null) {
  * 2. Partial matches (includes)
  * 3. Reference ID matching
  * 4. Flexible matching (split by '-' for compound colors)
- * 5. Priority-based fallback (-H.jpg, -BV.jpg, -B.jpg)
+ * 5. Priority-based fallback (-H.jpg, then model, then back types)
  *
  * @param {Array<string>} allMediaUrls - List of all media URLs to filter
  * @param {string} activeColor - The active color to filter by
@@ -497,15 +488,23 @@ export function filterMediaByColor(allMediaUrls, activeColor, colorMappings) {
       fallbackCandidates.push(mainImages[0]);
     }
 
-    // Priority 2: Back variant (-BV.jpg) or back main (-B.jpg) as fallback
-    const backVariantImages = allMediaUrls.filter(url => {
-      const filename = url.split('/').pop().split('?')[0].toLowerCase();
-      return filename.includes('-bv.jpg') || filename.endsWith('-bv.jpg');
+    const modelImages = allMediaUrls.filter((url) => {
+      const filename = url.split("/").pop().split("?")[0];
+      return filename.includes("-M.") || filename.includes("-M_");
     });
 
-    const backMainImages = allMediaUrls.filter(url => {
-      const filename = url.split('/').pop().split('?')[0].toLowerCase();
-      return filename.includes('-b.jpg') || filename.endsWith('-b.jpg');
+    if (modelImages.length > 0) {
+      fallbackCandidates.push(modelImages[0]);
+    }
+
+    const backVariantImages = allMediaUrls.filter((url) => {
+      const filename = url.split("/").pop().split("?")[0].toLowerCase();
+      return filename.includes("-bv.") || filename.includes("-bv_");
+    });
+
+    const backMainImages = allMediaUrls.filter((url) => {
+      const filename = url.split("/").pop().split("?")[0].toLowerCase();
+      return (filename.includes("-b.") || filename.includes("-b_")) && !filename.includes("-bv.");
     });
 
     if (backVariantImages.length > 0) {

--- a/assets/product-utils.test.js
+++ b/assets/product-utils.test.js
@@ -302,8 +302,16 @@ describe("sortImagesByDisplayRules", () => {
     // Check the order of URLs
     const sortedUrls = sortedImages.map(img => img.url);
 
-    // First position should be H.jpg (main)
     expect(sortedUrls[0]).toBe("ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-H.jpg");
+    expect(sortedUrls.slice(0, 4)).toEqual([
+      "ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-H.jpg",
+      "ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-M_1.jpg",
+      "ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-M_2.jpg",
+      "ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-M_3.jpg",
+    ]);
+    expect(sortedUrls.indexOf("ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-B.jpg")).toBeGreaterThan(
+      sortedUrls.indexOf("ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-M_1.jpg"),
+    );
 
     // Check that the first image is not hidden
     expect(sortedImages[0].hidden).toBe(false);
@@ -313,6 +321,22 @@ describe("sortImagesByDisplayRules", () => {
     expect(sortedUrls).toContain("ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-B.jpg");
     expect(sortedUrls).toContain("ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-M_1.jpg");
     expect(sortedUrls).toContain("ishaan-men-039-s-ski-softshell-winter-pants--NF-no-5009snw-darkblue-D_1.jpg");
+  });
+
+  test("keeps back types after hero and model shots", () => {
+    const sortedUrls = sortImagesByDisplayRules([
+      "product--NF-TR-5053OR-464-BV.jpg",
+      "product--NF-TR-5053OR-464-M_1.jpg",
+      "product--NF-TR-5053OR-464-H.jpg",
+      "product--NF-TR-5053OR-464-M_2.jpg",
+    ]).map((img) => img.url);
+
+    expect(sortedUrls).toEqual([
+      "product--NF-TR-5053OR-464-H.jpg",
+      "product--NF-TR-5053OR-464-M_1.jpg",
+      "product--NF-TR-5053OR-464-M_2.jpg",
+      "product--NF-TR-5053OR-464-BV.jpg",
+    ]);
   });
 
   test("handles single image correctly - should not be hidden", () => {

--- a/docs/color-thumbnail-logic.md
+++ b/docs/color-thumbnail-logic.md
@@ -152,8 +152,14 @@ When a color has no direct variant image and no same-reference media, `always` k
 
 ### 5. Product Cards
 **File**: `snippets/card-product.liquid`
-**Usage**: Color swatches on product listing pages
+**Usage**: Color swatches and the large card image on listing pages
 *Note: Uses custom logic instead of the utility for performance reasons*
+
+**Default card image** follows the same front-first, color-aware chain as swatches, scoped to `selected_or_first_available_variant`. Back type tokens (`-B` / `-BV`) are skipped when they are the variant featured image.
+
+**Hover is not required to be front.** Card hover swaps to the same color's model shot (`-M` or lowest `-M_N`). That file may be a photographic back (JIMEN / SUCHY `M_1`). Swatch hover still uses that color's `-H`.
+
+Media matching uses the exact `-<reference>-` token, so Shopify UUID suffixes such as `-M_1_<uuid>.jpg` still parse as type `M`. See `docs/product-card-media/evidence.md`.
 
 ## Example Scenario
 

--- a/docs/product-card-media/evidence.md
+++ b/docs/product-card-media/evidence.md
@@ -20,6 +20,22 @@ The `Men's fleece sweater BENDIK` card changed from a back-view asset to the low
 
 This verifies that the product-code token `MI` is no longer misread as the `M` image type.
 
+## Front-first default (2026-08-24)
+
+The default card image is now color-aware and front-first for `selected_or_first_available_variant`:
+
+1. `variant.featured_image` unless the filename is `-B` / `-BV`
+2. Same-reference `-H` → `-M` → lowest `-M_N` → `-D_N` → `-BV` → `-B`
+
+Hover is **not** required to be front. It uses the same color's model shot (`-M` or lowest `-M_N`). For JIMEN / SUCHY that is `M_1` (photographic back). That is accepted.
+
+| Product | Default | Hover | Swatches |
+| --- | --- | --- | --- |
+| JIMEN | `464-H` front | `464-M_1` back model | `464-H` / `300-H` |
+| SUCHY | `811-H` front | `811-M_1` back model | `811-H` / `170-H` |
+
+Do not treat `M_1` as a back-type token. `B` / `BV` are the only back types. JIMEN `300-M_1` is already a front.
+
 ### Transparent image background
 
 The transparent PNG card for `Men's luxury pants with full KREADY equipment` inherits the dark collection background before the change. After the change, its product media wrapper has a computed background of `rgb(255, 255, 255)`.

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -21,135 +21,161 @@
 
       {%- if card_product.media.size > 0 -%}
         {%- liquid
-          # ============================================================
-          # OPTIMIZATION: Single pass media indexing
-          # Instead of multiple loops over media, we do ONE pass to collect:
-          # - model_image_simple: -M without sequence
-          # - model_images_sequenced: -M_N with sequences (stored as string for sorting)
-          # - main_image: exact -H image type for hover
-          # - fallback images by type: H, B, BV, D
-          # ============================================================
-
+          # Canonical front-first order, color-aware:
+          # variant featured (unless B/BV) → H → M → M_N → D_N → BV → B
           assign model_image = null
           assign main_image = null
-          assign model_image_simple = null
-          assign best_sequenced_model = null
-          assign best_sequence_num = 999
-          assign alt_sequenced_model = null
-          assign alt_sequence_num = 999
-          assign fallback_h = null
-          assign fallback_b = null
-          assign fallback_bv = null
-          assign fallback_d = null
+          assign hero_media = null
+          assign model_media = null
+          assign model_sequence_media = null
+          assign detail_media = null
+          assign back_variant_media = null
+          assign back_media = null
+          assign lowest_model_sequence = 999
+          assign lowest_detail_sequence = 999
+          assign card_variant = card_product.selected_or_first_available_variant
+          assign reference_id = ''
 
-          for media in card_product.media
-            assign media_src = media.src | default: ''
-            assign parsed_url = media_src | split: '/' | last | split: '?' | first
-            assign filename_without_extension = parsed_url | split: '.' | first
-            assign filename_parts = filename_without_extension | split: '-'
-            assign image_type_token = filename_parts | last
-            assign image_type_parts = image_type_token | split: '_'
-            assign image_type = image_type_parts.first
-            assign image_sequence = 0
-            if image_type_parts.size > 1
-              assign image_sequence = image_type_parts[1] | plus: 0
+          if card_variant.featured_image
+            assign featured_filename = card_variant.featured_image.src | default: '' | split: '/' | last | split: '?' | first
+            assign featured_is_back = false
+            if featured_filename contains '-BV.' or featured_filename contains '-BV_'
+              assign featured_is_back = true
+            elsif featured_filename contains '-B.' or featured_filename contains '-B_'
+              assign featured_is_back = true
             endif
-
-            # Match the final image-type token so product codes such as MI and BU
-            # are not mistaken for model and back images.
-            if image_type == 'H'
-              if main_image == null
-                assign main_image = media
-              endif
-            endif
-
-            # Check for model images
-            if image_type == 'M'
-              if image_sequence > 0
-                if image_sequence < best_sequence_num
-                  # Track for primary model (lowest sequence)
-                  assign best_sequence_num = image_sequence
-                  assign best_sequenced_model = media
-                endif
-              else
-                # Simple model image (no sequence) - highest priority
-                if model_image_simple == null
-                  assign model_image_simple = media
-                endif
-              endif
-            endif
-
-            # Collect fallback images by type (first match only)
-            if fallback_h == null and image_type == 'H'
-              assign fallback_h = media
-            endif
-            if fallback_b == null and image_type == 'B'
-              assign fallback_b = media
-            endif
-            if fallback_bv == null and image_type == 'BV'
-              assign fallback_bv = media
-            endif
-            if fallback_d == null and image_type == 'D'
-              assign fallback_d = media
-            endif
-          endfor
-
-          # Resolve model_image with priority: simple -M > sequenced -M_N > fallbacks > featured
-          if model_image_simple
-            assign model_image = model_image_simple
-          elsif best_sequenced_model
-            assign model_image = best_sequenced_model
-          elsif fallback_h
-            assign model_image = fallback_h
-          elsif fallback_b
-            assign model_image = fallback_b
-          elsif fallback_bv
-            assign model_image = fallback_bv
-          elsif fallback_d
-            assign model_image = fallback_d
-          else
-            assign model_image = card_product.featured_media
+            unless featured_is_back
+              assign model_image = card_variant.featured_image
+            endunless
           endif
 
-          # Find alternative model for hover if no -H image found
-          unless main_image
-            # Look for a different sequenced model image
-            if best_sequenced_model and model_image_simple
-              # If we used simple model, use sequenced as alternative
-              assign main_image = best_sequenced_model
-            else
-              # Find next lowest sequence model image different from current
-              for media in card_product.media
-                assign media_src = media.src | default: ''
-                assign parsed_url = media_src | split: '/' | last | split: '?' | first
-                assign filename_without_extension = parsed_url | split: '.' | first
-                assign filename_parts = filename_without_extension | split: '-'
-                assign image_type_token = filename_parts | last
-                assign image_type_parts = image_type_token | split: '_'
-                assign image_type = image_type_parts.first
-                assign image_sequence = 0
-                if image_type_parts.size > 1
-                  assign image_sequence = image_type_parts[1] | plus: 0
-                endif
-                if image_type == 'M' and image_sequence > 0 and media.id != model_image.id
-                  if image_sequence < alt_sequence_num
-                    assign alt_sequence_num = image_sequence
-                    assign alt_sequenced_model = media
-                  endif
-                endif
-              endfor
-
-              if alt_sequenced_model
-                assign main_image = alt_sequenced_model
-              else
-                assign main_image = model_image
+          if card_variant.sku != blank
+            assign sku_parts = card_variant.sku | split: '-'
+            assign reference_index = sku_parts.size | minus: 2
+            if reference_index >= 0
+              assign sku_reference_id = sku_parts[reference_index] | strip
+              assign sku_reference_number = sku_reference_id | plus: 0
+              if sku_reference_number > 0
+                assign reference_id = sku_reference_id
               endif
             endif
-          endunless
+          endif
 
-          # Check if we have a real hover image
+          if reference_id == '' and card_product.metafields.custom.color.value != blank
+            assign variant_color_value = card_variant.option1 | default: '' | downcase | strip | replace: ' ', '-' | replace: "'", '' | replace: '.', '' | replace: ',', ''
+            for color_item in card_product.metafields.custom.color.value
+              assign handle_root = color_item.system.handle | split: '-' | first | downcase
+              if color_item.name == variant_color_value or handle_root == variant_color_value
+                assign reference_id = color_item.reference_id
+                break
+              endif
+            endfor
+          endif
+
+          if reference_id != ''
+            assign reference_token = '-' | append: reference_id | append: '-'
+            for media in card_product.media
+              assign media_src = media.src | default: ''
+              assign filename = media_src | split: '/' | last | split: '?' | first
+              if filename contains reference_token
+                assign type_token = filename | split: reference_token | last | split: '.' | first
+                assign type_parts = type_token | split: '_'
+                assign type_name = type_parts.first
+                assign type_sequence = 0
+                if type_parts.size > 1
+                  assign type_sequence = type_parts[1] | plus: 0
+                endif
+
+                if type_name == 'H' and hero_media == null
+                  assign hero_media = media
+                elsif type_name == 'M'
+                  if type_sequence > 0
+                    if type_sequence < lowest_model_sequence
+                      assign lowest_model_sequence = type_sequence
+                      assign model_sequence_media = media
+                    endif
+                  elsif model_media == null
+                    assign model_media = media
+                  endif
+                elsif type_name == 'D' and type_sequence > 0
+                  if type_sequence < lowest_detail_sequence
+                    assign lowest_detail_sequence = type_sequence
+                    assign detail_media = media
+                  endif
+                elsif type_name == 'BV' and back_variant_media == null
+                  assign back_variant_media = media
+                elsif type_name == 'B' and back_media == null
+                  assign back_media = media
+                endif
+              endif
+            endfor
+          endif
+
+          if model_image == null
+            assign model_image = hero_media | default: model_media | default: model_sequence_media | default: detail_media | default: back_variant_media | default: back_media
+          endif
+
+          assign main_image = model_media | default: model_sequence_media
+          if main_image == null
+            if hero_media != blank and model_image != blank and hero_media.id != model_image.id
+              assign main_image = hero_media
+            else
+              assign main_image = detail_media
+            endif
+          elsif model_image != blank and main_image.id == model_image.id
+            if hero_media != blank and hero_media.id != model_image.id
+              assign main_image = hero_media
+            else
+              assign main_image = detail_media
+            endif
+          endif
+
+          if model_image == null
+            assign fallback_h = null
+            assign fallback_m = null
+            assign fallback_m_seq = null
+            assign fallback_m_seq_num = 999
+            assign fallback_d = null
+            assign fallback_bv = null
+            assign fallback_b = null
+            for media in card_product.media
+              assign filename = media.src | default: '' | split: '/' | last | split: '?' | first
+              if filename contains '-H.' or filename contains '-H_'
+                if fallback_h == null
+                  assign fallback_h = media
+                endif
+              elsif filename contains '-M.'
+                if fallback_m == null
+                  assign fallback_m = media
+                endif
+              elsif filename contains '-M_'
+                assign seq_part = filename | split: '-M_' | last | split: '.' | first | split: '_' | first | plus: 0
+                if seq_part > 0 and seq_part < fallback_m_seq_num
+                  assign fallback_m_seq_num = seq_part
+                  assign fallback_m_seq = media
+                endif
+              elsif filename contains '-D_'
+                if fallback_d == null
+                  assign fallback_d = media
+                endif
+              elsif filename contains '-BV.' or filename contains '-BV_'
+                if fallback_bv == null
+                  assign fallback_bv = media
+                endif
+              elsif filename contains '-B.' or filename contains '-B_'
+                if fallback_b == null
+                  assign fallback_b = media
+                endif
+              endif
+            endfor
+            assign model_image = fallback_h | default: fallback_m | default: fallback_m_seq | default: fallback_d | default: fallback_bv | default: fallback_b | default: card_product.featured_media
+            if main_image == null
+              assign main_image = fallback_m | default: fallback_m_seq | default: fallback_h
+            endif
+          endif
+
           assign has_real_main_image = false
-          if main_image and main_image.id != model_image.id
+          if main_image and model_image and main_image.id != model_image.id
             assign has_real_main_image = true
           endif
         -%}

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -552,9 +552,60 @@
     assign active_color_data_attr = active_color_value
   endif
 
-  # Keep the server-rendered candidate stable through hydration. The runtime
-  # receives this ID and uses it as the initial item in the same sequence.
-  assign initial_media = first_variant.featured_media | default: product.featured_media | default: product.media.first
+  # Front-first initial frame for the selected color. Do not start on B/BV
+  # just because Shopify featured media happens to be a back shot.
+  assign initial_media = null
+  assign initial_featured = first_variant.featured_media | default: first_variant.featured_image
+  if initial_featured
+    assign initial_featured_src = initial_featured.preview_image.src | default: initial_featured.src | default: ''
+    assign initial_featured_file = initial_featured_src | split: '/' | last | split: '?' | first
+    assign initial_featured_is_back = false
+    if initial_featured_file contains '-BV.' or initial_featured_file contains '-BV_'
+      assign initial_featured_is_back = true
+    elsif initial_featured_file contains '-B.' or initial_featured_file contains '-B_'
+      assign initial_featured_is_back = true
+    endif
+    unless initial_featured_is_back
+      assign initial_media = initial_featured
+    endunless
+  endif
+
+  if initial_media == null and active_color_reference_id != ''
+    assign gallery_reference_token = '-' | append: active_color_reference_id | append: '-'
+    assign gallery_hero_media = null
+    assign gallery_model_media = null
+    assign gallery_model_sequence_media = null
+    assign gallery_lowest_model_sequence = 999
+    for media in product.media
+      assign gallery_filename = media.src | default: '' | split: '/' | last | split: '?' | first
+      if gallery_filename contains gallery_reference_token
+        assign gallery_type_token = gallery_filename | split: gallery_reference_token | last | split: '.' | first
+        assign gallery_type_parts = gallery_type_token | split: '_'
+        assign gallery_type_name = gallery_type_parts.first
+        assign gallery_type_sequence = 0
+        if gallery_type_parts.size > 1
+          assign gallery_type_sequence = gallery_type_parts[1] | plus: 0
+        endif
+        if gallery_type_name == 'H' and gallery_hero_media == null
+          assign gallery_hero_media = media
+        elsif gallery_type_name == 'M'
+          if gallery_type_sequence > 0
+            if gallery_type_sequence < gallery_lowest_model_sequence
+              assign gallery_lowest_model_sequence = gallery_type_sequence
+              assign gallery_model_sequence_media = media
+            endif
+          elsif gallery_model_media == null
+            assign gallery_model_media = media
+          endif
+        endif
+      endif
+    endfor
+    assign initial_media = gallery_hero_media | default: gallery_model_media | default: gallery_model_sequence_media
+  endif
+
+  if initial_media == null
+    assign initial_media = first_variant.featured_media | default: product.featured_media | default: product.media.first
+  endif
   assign initial_image = initial_media.preview_image | default: initial_media
   assign initial_media_id = initial_media.id | default: ''
   assign initial_media_ratio = initial_image.aspect_ratio | default: 1

--- a/tests/product-card-media-source.test.js
+++ b/tests/product-card-media-source.test.js
@@ -5,14 +5,15 @@ import { describe, expect, test } from "vitest";
 const readProjectFile = (path) => readFileSync(fileURLToPath(new URL(`../${path}`, import.meta.url)), "utf8");
 
 describe("product card media rendering", () => {
-  test("matches the final image type token instead of product-code substrings", () => {
+  test("picks the selected color front-first instead of a global model shot", () => {
     const source = readProjectFile("snippets/card-product.liquid");
 
-    expect(source).toContain("assign image_type_token = filename_parts | last");
-    expect(source).toContain("if image_type == 'M'");
-    expect(source).toContain("if image_type == 'H'");
+    expect(source).toContain("selected_or_first_available_variant");
+    expect(source).toContain("featured_is_back");
+    expect(source).toContain("hero_media | default: model_media | default: model_sequence_media");
+    expect(source).toContain("assign type_name = type_parts.first");
     expect(source).not.toContain("parsed_url contains '-M'");
-    expect(source).not.toContain("parsed_url contains '-B'");
+    expect(source).not.toContain("assign image_type_token = filename_parts | last");
   });
 
   test("adds a white background to native and EComposer product media wrappers", () => {

--- a/tests/product-media-gallery-sequence.test.js
+++ b/tests/product-media-gallery-sequence.test.js
@@ -86,6 +86,20 @@ describe("resolveProductMediaSequence", () => {
     expect(resolved.slice(1).map((item) => item.mediaId)).toEqual(["main", "video", "detail", "other-color"]);
   });
 
+  test("does not pin a back-type featured image ahead of the front-first sequence", () => {
+    const media = [
+      image("hero", "shirt--NF-TR-3549SKP-811-H.jpg"),
+      image("model", "shirt--NF-TR-3549SKP-811-M_1.jpg"),
+      image("back", "shirt--NF-TR-3549SKP-811-BV.jpg"),
+    ];
+    const resolved = resolveProductMediaSequence({
+      media,
+      initialMediaId: "back",
+    });
+
+    expect(resolved.map((item) => item.mediaId)).toEqual(["hero", "model", "back"]);
+  });
+
   test.each(["model", "external_video"])("retains non-image media objects: %s", (mediaType) => {
     const special =
       mediaType === "model"


### PR DESCRIPTION
## Summary
- Product cards were picking a product-global `-M_1`, which is often a photographic back view (JIMEN `464-M_1`, SUCHY `811-M_1`) even when the first swatch color already has a front hero.
- Default card image and PDP first frame now follow the selected/first-available variant: featured unless `-B`/`-BV`, then same-ref `H → M → M_N → D → BV → B`.
- Card hover still uses the same-color model shot, which may be a back photo. PDP no longer pins an initial back featured image to the front of the gallery.

## Test plan
- [ ] Collection/search card for JIMEN (`8961-tr-5053or-men-s-outdoor-merino-t-shirt-jimen`): default image is front (`-H`), not `464-M_1`
- [ ] Hover JIMEN card: same-color model (`464-M_1`) is acceptable even if it is a back view
- [ ] Collection/search card for SUCHY (`tr-3549ksp-mens-ski-touring-merino-t-shirt-suchy`): default image is first-available variant front (`170-H`), not featured `811-BV`
- [ ] JIMEN and SUCHY PDPs: first gallery frame is the selected variant front, not BV
- [ ] Switch color swatches on a card and confirm the large image updates to that color’s front hero
- [ ] `pnpm test:ci` (already passing locally, 72 tests)
- Draft preview already verified on intl: https://shop.northfinder.com/?preview_theme_id=204239503692