### PR TITLE
fix(mega-menu): make category headings clickable

### DIFF
--- a/assets/component-mega-menu.css
+++ b/assets/component-mega-menu.css
@@ -97,7 +97,7 @@
 .mega-menu__sublist {
   display: flex;
   flex-direction: column;
-  gap: 1rem; /* 16px between items (Figma) */
+  gap: 0.75rem; /* 12px between items so jacket types group tighter */
   list-style: none;
   margin: 0;
   padding: 0;

--- a/snippets/header-mega-menu.liquid
+++ b/snippets/header-mega-menu.liquid
@@ -112,7 +112,7 @@
                       {%- for childlink in link.links -%}
                         {%- if childlink.url == link.url -%}{%- continue -%}{%- endif -%}
                         <li class="mega-menu__col">
-                          {%- if childlink.links == blank and childlink.url != blank -%}
+                          {%- if childlink.url != blank -%}
                             <a
                               id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
                               href="{{ childlink.url }}"

--- a/tests/menu-navigation-source.test.js
+++ b/tests/menu-navigation-source.test.js
@@ -16,6 +16,14 @@ describe("merchant-authored navigation links", () => {
     expect(source).toContain("{{ grandchildlink.title | escape }}");
   });
 
+  test("desktop category headings stay links when they have child items", () => {
+    const source = readSnippet("header-mega-menu.liquid");
+
+    expect(source).not.toContain("childlink.links == blank and childlink.url != blank");
+    expect(source).toContain("if childlink.url != blank");
+    expect(source).toContain("mega-menu__heading mega-menu__heading--link");
+  });
+
   test("mobile renders authored links and only falls back to generated CTAs", () => {
     const source = readSnippet("menu-drawer-panel.liquid");
 


### PR DESCRIPTION
## Summary
- Desktop mega menu category headings (e.g. Men's Jackets) now render as links when Admin already has a URL, even if the item has children.
- Tightens jacket-type spacing in the mega menu sublist from 16px to 12px.
- Desktop-only Liquid/CSS; mobile drawer markup and interactions are unchanged.

## Test plan
- [ ] Preview draft theme on desktop: open Men, confirm Men's Jackets / Men's Trousers / Men's Fleece headings are clickable and go to their collection URLs.
- [ ] Confirm child links (Hiking Jackets, All Jackets, etc.) still work and hover/open behavior of the mega panel is unchanged.
- [ ] Mobile drawer: hamburger → Men → Men's Jackets still opens the nested tile panel (does not navigate away); Back works; All / type tiles still navigate.
- [ ] `pnpm exec vitest run tests/menu-navigation-source.test.js`