### PR TITLE
fix(pdp): wrap description richtext so GitHub theme sync can validate

### DIFF
--- a/templates/product.json
+++ b/templates/product.json
@@ -69,7 +69,7 @@
           "settings": {
             "heading": "Product description",
             "icon": "none",
-            "content": "{{ product.description }}{{ product.metafields.custom.short_description.value }}",
+            "content": "<p>{{ product.description }}{{ product.metafields.custom.short_description.value }}</p>",
             "page": ""
           }
         },

--- a/templates/product.northkit.json
+++ b/templates/product.northkit.json
@@ -69,7 +69,7 @@
           "settings": {
             "heading": "Product description",
             "icon": "none",
-            "content": "{{ product.description }}{{ product.metafields.custom.short_description.value }}",
+            "content": "<p>{{ product.description }}{{ product.metafields.custom.short_description.value }}</p>",
             "page": ""
           }
         },

--- a/templates/product.parfums.json
+++ b/templates/product.parfums.json
@@ -69,7 +69,7 @@
           "settings": {
             "heading": "Product description",
             "icon": "none",
-            "content": "{{ product.description }}{{ product.metafields.custom.short_description.value }}",
+            "content": "<p>{{ product.description }}{{ product.metafields.custom.short_description.value }}</p>",
             "page": ""
           }
         },


### PR DESCRIPTION
## Summary
- PR #89 removed leftover Apps sections but also stripped the `<p>` wrapper around the Product description richtext.
- Shopify GitHub theme sync requires richtext `content` top-level nodes to be `<p>`, `<ul>`, `<ol>`, or `<h1>`–`<h6>`, so sync failed on `product.json`, `product.northkit.json`, and `product.parfums.json`.
- Restore the required `<p>` wrappers so theme updates from GitHub succeed.

## Test plan
- [ ] GitHub → Shopify theme sync reports 3 succeeded for those product templates
- [ ] Default / Northkit / Parfums PDPs still show the Product description tab
- [ ] Theme Editor can save a normal section/block change on the default product template