### PR TITLE
fix(pdp): source FAQ items from shared faq_item metaobjects

### DIFF
--- a/sections/faq-section.liquid
+++ b/sections/faq-section.liquid
@@ -115,29 +115,106 @@
     </div>
 
     <div class="faq-section__content">
-      {%- for block in section.blocks -%}
-        <div class="accordion" {{ block.shopify_attributes }}>
-          <details
-            id="Details-{{ block.id }}-{{ section.id }}"
-            {% if section.settings.open_first_item and forloop.first %}
-            open
-            {% endif %}>
-            <summary id="Summary-{{ block.id }}-{{ section.id }}">
-              <h3 class="accordion__title inline-richtext">
-                {{ block.settings.question }}
-              </h3>
-              {{- 'icon-caret.svg' | inline_asset_content -}}
-            </summary>
-            <div
-              class="accordion__content rte"
-              id="FAQAccordion-{{ block.id }}-{{ section.id }}"
-              role="region"
-              aria-labelledby="Summary-{{ block.id }}-{{ section.id }}">
-              {{ block.settings.answer }}
+      {%- liquid
+        assign featured_faqs = section.settings.faq_entries
+        assign use_faq_picker = false
+        if featured_faqs != blank
+          assign use_faq_picker = true
+        endif
+        assign faq_catalog_count = shop.metaobjects.faq_item.values_count | default: 0
+        assign use_faq_catalog = false
+        if use_faq_picker == false and faq_catalog_count > 0
+          assign use_faq_catalog = true
+        endif
+        assign faq_limit = section.settings.max_items | default: 4
+        assign rendered_faqs = 0
+      -%}
+      {%- if use_faq_picker -%}
+        {%- for faq in featured_faqs -%}
+          {%- assign faq_id = faq.system.handle | default: faq.system.id -%}
+          <div class="accordion">
+            <details
+              id="Details-{{ faq_id }}-{{ section.id }}"
+              {% if section.settings.open_first_item and forloop.first %}
+                open
+              {% endif %}
+            >
+              <summary id="Summary-{{ faq_id }}-{{ section.id }}">
+                <h3 class="accordion__title inline-richtext">
+                  {{ faq.question.value }}
+                </h3>
+                {{- 'icon-caret.svg' | inline_asset_content -}}
+              </summary>
+              <div
+                class="accordion__content rte"
+                id="FAQAccordion-{{ faq_id }}-{{ section.id }}"
+                role="region"
+                aria-labelledby="Summary-{{ faq_id }}-{{ section.id }}"
+              >
+                {{ faq.answer | metafield_tag }}
+              </div>
+            </details>
+          </div>
+        {%- endfor -%}
+      {%- elsif use_faq_catalog -%}
+        {%- for i in (1..faq_limit) -%}
+          {%- assign faq_handle = 'faq-' | append: i -%}
+          {%- assign faq = shop.metaobjects.faq_item[faq_handle] -%}
+          {%- if faq != blank -%}
+            {%- assign rendered_faqs = rendered_faqs | plus: 1 -%}
+            {%- assign faq_id = faq.system.handle | default: faq.system.id -%}
+            <div class="accordion">
+              <details
+                id="Details-{{ faq_id }}-{{ section.id }}"
+                {% if section.settings.open_first_item and rendered_faqs == 1 %}
+                  open
+                {% endif %}
+              >
+                <summary id="Summary-{{ faq_id }}-{{ section.id }}">
+                  <h3 class="accordion__title inline-richtext">
+                    {{ faq.question.value }}
+                  </h3>
+                  {{- 'icon-caret.svg' | inline_asset_content -}}
+                </summary>
+                <div
+                  class="accordion__content rte"
+                  id="FAQAccordion-{{ faq_id }}-{{ section.id }}"
+                  role="region"
+                  aria-labelledby="Summary-{{ faq_id }}-{{ section.id }}"
+                >
+                  {{ faq.answer | metafield_tag }}
+                </div>
+              </details>
             </div>
-          </details>
-        </div>
-      {%- endfor -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- else -%}
+        {%- for block in section.blocks -%}
+          <div class="accordion" {{ block.shopify_attributes }}>
+            <details
+              id="Details-{{ block.id }}-{{ section.id }}"
+              {% if section.settings.open_first_item and forloop.first %}
+                open
+              {% endif %}
+            >
+              <summary id="Summary-{{ block.id }}-{{ section.id }}">
+                <h3 class="accordion__title inline-richtext">
+                  {{ block.settings.question }}
+                </h3>
+                {{- 'icon-caret.svg' | inline_asset_content -}}
+              </summary>
+              <div
+                class="accordion__content rte"
+                id="FAQAccordion-{{ block.id }}-{{ section.id }}"
+                role="region"
+                aria-labelledby="Summary-{{ block.id }}-{{ section.id }}"
+              >
+                {{ block.settings.answer }}
+              </div>
+            </details>
+          </div>
+        {%- endfor -%}
+      {%- endif -%}
     </div>
   </div>
 </div>
@@ -151,6 +228,24 @@
       "groups": ["header", "footer"]
     },
     "settings": [
+      {
+        "type": "metaobject_list",
+        "id": "faq_entries",
+        "label": "FAQ items",
+        "metaobject_type": "faq_item",
+        "limit": 50,
+        "info": "Pick items from Content → Metaobjects → FAQ item. Leave empty to show the first items by Position."
+      },
+      {
+        "type": "range",
+        "id": "max_items",
+        "min": 1,
+        "max": 12,
+        "step": 1,
+        "default": 4,
+        "label": "Items if none selected",
+        "info": "Used only when the FAQ items picker is empty."
+      },
       {
         "type": "text",
         "id": "heading",

--- a/sections/faq-tabbed-section.liquid
+++ b/sections/faq-tabbed-section.liquid
@@ -25,6 +25,11 @@
   if categories.size > 0 and default_category == blank
     assign default_category = categories.first.settings.category_id
   endif
+  assign faq_catalog_count = shop.metaobjects.faq_item.values_count | default: 0
+  assign use_faq_metaobjects = false
+  if faq_catalog_count > 0
+    assign use_faq_metaobjects = true
+  endif
 -%}
 
 <div class="color-{{ section.settings.color_scheme }} gradient bg-[#f7f7f7] h-full">
@@ -106,32 +111,60 @@
             {%- assign current_category_id = category.settings.category_id | strip | downcase -%}
             {%- assign matching_faqs = 0 -%}
 
-            {%- for block in section.blocks -%}
-              {%- if block.type == 'faq_item' -%}
-                {%- assign block_category = block.settings.category | strip | downcase -%}
-                {%- if block_category == current_category_id -%}
+            {%- if use_faq_metaobjects -%}
+              {%- for faq in shop.metaobjects.faq_item.values -%}
+                {%- assign faq_category = faq.category.value | strip | downcase -%}
+                {%- if faq_category == current_category_id -%}
                   {%- assign matching_faqs = matching_faqs | plus: 1 -%}
-                  <div class="accordion" {{ block.shopify_attributes }}>
-                    <details id="Details-{{ block.id }}-{{ section.id }}">
-                      <summary id="Summary-{{ block.id }}-{{ section.id }}">
+                  {%- assign faq_id = faq.system.handle | default: faq.system.id -%}
+                  <div class="accordion">
+                    <details id="Details-{{ faq_id }}-{{ section.id }}">
+                      <summary id="Summary-{{ faq_id }}-{{ section.id }}">
                         <h3 class="accordion__title inline-richtext">
-                          {{ block.settings.question }}
+                          {{ faq.question.value }}
                         </h3>
                         {{- 'icon-caret.svg' | inline_asset_content -}}
                       </summary>
                       <div
                         class="accordion__content rte"
-                        id="FAQAccordion-{{ block.id }}-{{ section.id }}"
+                        id="FAQAccordion-{{ faq_id }}-{{ section.id }}"
                         role="region"
-                        aria-labelledby="Summary-{{ block.id }}-{{ section.id }}"
+                        aria-labelledby="Summary-{{ faq_id }}-{{ section.id }}"
                       >
-                        {{ block.settings.answer }}
+                        {{ faq.answer | metafield_tag }}
                       </div>
                     </details>
                   </div>
                 {%- endif -%}
-              {%- endif -%}
-            {%- endfor -%}
+              {%- endfor -%}
+            {%- else -%}
+              {%- for block in section.blocks -%}
+                {%- if block.type == 'faq_item' -%}
+                  {%- assign block_category = block.settings.category | strip | downcase -%}
+                  {%- if block_category == current_category_id -%}
+                    {%- assign matching_faqs = matching_faqs | plus: 1 -%}
+                    <div class="accordion" {{ block.shopify_attributes }}>
+                      <details id="Details-{{ block.id }}-{{ section.id }}">
+                        <summary id="Summary-{{ block.id }}-{{ section.id }}">
+                          <h3 class="accordion__title inline-richtext">
+                            {{ block.settings.question }}
+                          </h3>
+                          {{- 'icon-caret.svg' | inline_asset_content -}}
+                        </summary>
+                        <div
+                          class="accordion__content rte"
+                          id="FAQAccordion-{{ block.id }}-{{ section.id }}"
+                          role="region"
+                          aria-labelledby="Summary-{{ block.id }}-{{ section.id }}"
+                        >
+                          {{ block.settings.answer }}
+                        </div>
+                      </details>
+                    </div>
+                  {%- endif -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%}
 
             {%- if matching_faqs == 0 -%}
               <p class="faq-empty-message">{{ 'sections.faq.no_questions' | t }}</p>
@@ -363,12 +396,16 @@
     "groups": ["header", "footer"]
   },
   "settings": [
-    {
-      "type": "text",
-      "id": "heading",
-      "default": "FAQ",
-      "label": "Heading"
-    },
+      {
+        "type": "text",
+        "id": "heading",
+        "default": "FAQ",
+        "label": "Heading"
+      },
+      {
+        "type": "paragraph",
+        "content": "Questions come from Content → Metaobjects → FAQ item, grouped by the Category field. Category tabs below only control tab labels."
+      },
     {
       "type": "text",
       "id": "default_category",

--- a/templates/product.json
+++ b/templates/product.json
@@ -227,6 +227,8 @@
       ],
       "settings": {
         "heading": "FAQs",
+        "faq_entries": ["faq-1", "faq-2", "faq-3", "faq-4"],
+        "max_items": 4,
         "open_first_item": false,
         "view_all_link": "shopify://pages/faq",
         "color_scheme": "",

--- a/templates/product.northkit.json
+++ b/templates/product.northkit.json
@@ -196,6 +196,8 @@
       "block_order": ["faq_item_JP4qdB", "faq_item_MnXMMP", "faq_item_mhif3f", "faq_item_MKXJWT"],
       "settings": {
         "heading": "FAQs",
+        "faq_entries": ["faq-1", "faq-2", "faq-3", "faq-4"],
+        "max_items": 4,
         "open_first_item": false,
         "view_all_link": "shopify://pages/faq",
         "color_scheme": "",


### PR DESCRIPTION
## Summary
- PDP and FAQ page now read Q&As from the storefront `faq_item` metaobject catalog instead of hardcoded Theme Editor blocks, so every product shares the same real answers.
- Merchants pick the PDP subset (and order) via a `metaobject_list` setting; if the picker is empty, the section falls back to `faq-1`…`faq-N` (default 4).
- Verified on unpublished draft theme `Draft FAQ metaobjects` (#204341707084): PDP shows the 4 shipping FAQs with real answers; `/pages/faq?view=faq` shows all 31 items across 6 tabs.

## Test plan
- [ ] Preview draft theme: `https://shop.northfinder.com/products/3-parts-poles-hiking-aluminium-135?preview_theme_id=204341707084`
- [ ] Confirm PDP FAQ is 4 distinct English questions with real answers (not the Slovak placeholder)
- [ ] Open an accordion and confirm rich-text answer renders
- [ ] Click “view all questions” — note `/pages/faq` is still on the default `page` template; use `?view=faq` until that page is assigned the `faq` template
- [ ] Preview FAQ page: `https://shop.northfinder.com/pages/faq?view=faq&preview_theme_id=204341707084` — 31 items, 6 category tabs switch correctly
- [ ] In Theme Editor, change the FAQ items picker / “Items if none selected” and confirm PDP count/order updates
- [ ] Do not publish until Translate & Adapt has localized the 31 metaobjects